### PR TITLE
Ajoute les workflows CI/CD GitHub Actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+**/bin/
+**/obj/
+.vs/
+.idea/
+
+**/[Tt]est[Rr]esult*/
+*.trx
+coverage-report/
+
+.git/
+.env
+data/
+*.db
+*.db-shm
+*.db-wal
+logs/

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: CD
 
 on:
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,79 @@
+name: CD
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore
+        run: dotnet restore RaindropAI.slnx
+
+      - name: Build
+        run: dotnet build RaindropAI.slnx -c Release --no-restore
+
+      - name: Test
+        run: dotnet test RaindropAI.slnx -c Release --no-build -- --coverage --coverage-output-format cobertura
+
+      - name: Install ReportGenerator
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate coverage report
+        run: |
+          reportgenerator \
+            "-reports:**/TestResults/*.cobertura.xml" \
+            "-targetdir:coverage-report" \
+            "-reporttypes:Html;MarkdownSummaryGithub" \
+            "-assemblyfilters:-*Tests*"
+          cat coverage-report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+
+  publish:
+    name: Publish Docker
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Login to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Metadata raindropai-worker
+        id: meta-worker
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/raindropai-worker
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest
+
+      - name: Push raindropai-worker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: src/RaindropAI.Worker/Dockerfile
+          push: true
+          tags: ${{ steps.meta-worker.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore
+        run: dotnet restore RaindropAI.slnx
+
+      - name: Build
+        run: dotnet build RaindropAI.slnx -c Release --no-restore
+
+      - name: Test
+        run: dotnet test RaindropAI.slnx -c Release --no-build -- --coverage --coverage-output-format cobertura
+
+      - name: Install ReportGenerator
+        run: dotnet tool install -g dotnet-reportgenerator-globaltool
+
+      - name: Generate coverage report
+        run: |
+          reportgenerator \
+            "-reports:**/TestResults/*.cobertura.xml" \
+            "-targetdir:coverage-report" \
+            "-reporttypes:Html;MarkdownSummaryGithub" \
+            "-assemblyfilters:-*Tests*"
+          cat coverage-report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+
+      - name: PR Coverage Comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          recreate: true
+          path: coverage-report/SummaryGithub.md
+
+  docker:
+    name: Docker Build
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build raindropai-worker
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: src/RaindropAI.Worker/Dockerfile
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ obj/
 ## Test results
 [Tt]est[Rr]esult*/
 *.trx
+coverage-report/
 
 ## Runtime data / secrets
 .env

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="18.9.0" />
     <PackageVersion Include="NSubstitute" Version="5.3.0" />
     <PackageVersion Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageVersion Include="Serilog.Settings.Configuration" Version="10.0.1" />

--- a/src/RaindropAI.Worker/Dockerfile
+++ b/src/RaindropAI.Worker/Dockerfile
@@ -1,7 +1,6 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
-COPY RaindropAI.sln .
 COPY src/RaindropAI.Core/RaindropAI.Core.csproj src/RaindropAI.Core/
 COPY src/RaindropAI.Infrastructure/RaindropAI.Infrastructure.csproj src/RaindropAI.Infrastructure/
 COPY src/RaindropAI.Worker/RaindropAI.Worker.csproj src/RaindropAI.Worker/

--- a/src/RaindropAI.Worker/Dockerfile
+++ b/src/RaindropAI.Worker/Dockerfile
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /src
 
+COPY Directory.Build.props Directory.Packages.props ./
 COPY src/RaindropAI.Core/RaindropAI.Core.csproj src/RaindropAI.Core/
 COPY src/RaindropAI.Infrastructure/RaindropAI.Infrastructure.csproj src/RaindropAI.Infrastructure/
 COPY src/RaindropAI.Worker/RaindropAI.Worker.csproj src/RaindropAI.Worker/

--- a/tests/RaindropAI.Core.Tests/RaindropAI.Core.Tests.csproj
+++ b/tests/RaindropAI.Core.Tests/RaindropAI.Core.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit.v3.mtp-v2" />
   </ItemGroup>

--- a/tests/RaindropAI.Infrastructure.Tests/RaindropAI.Infrastructure.Tests.csproj
+++ b/tests/RaindropAI.Infrastructure.Tests/RaindropAI.Infrastructure.Tests.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="WireMock.Net" />
     <PackageReference Include="xunit.v3.mtp-v2" />


### PR DESCRIPTION
## Summary
- Ajoute `ci.yml` (PR vers `main`) : build/test avec couverture, commentaire de couverture sur la PR, et vérification du build Docker du Worker.
- Ajoute `cd.yml` (push sur `main`) : build/test avec couverture puis publication de l'image `raindropai-worker` sur `ghcr.io`.
- Corrige `src/RaindropAI.Worker/Dockerfile` qui copiait encore `RaindropAI.sln`, disparu depuis la migration vers `.slnx` (aurait fait échouer tout build Docker).
- Ajoute `Microsoft.Testing.Extensions.CodeCoverage` aux projets de tests : ce repo tourne sur Microsoft.Testing.Platform (xUnit v3), pas vstest classique, donc `--collect:"XPlat Code Coverage"` ne fonctionne pas ici.

## Test plan
- [x] `dotnet restore/build/test RaindropAI.slnx` vérifiés en local (45 tests, 94.9% de couverture de lignes)
- [x] Rapport de couverture généré localement avec `reportgenerator` sur `**/TestResults/*.cobertura.xml`
- [ ] `docker build` complet non vérifié en local (Docker Desktop indisponible pendant la session)
- [ ] Étapes ghcr.io / commentaire PR à valider en conditions réelles sur GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)