### PR TITLE
Ajoute une version SemVer et tague l'image Docker publiée

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,8 @@ jobs:
     permissions:
       contents: read
       checks: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -20,6 +22,10 @@ jobs:
 
       - name: Restore
         run: dotnet restore RaindropAI.slnx
+
+      - name: Get version
+        id: version
+        run: echo "version=$(dotnet build src/RaindropAI.Worker/RaindropAI.Worker.csproj -getProperty:Version --nologo)" >> "$GITHUB_OUTPUT"
 
       - name: Build
         run: dotnet build RaindropAI.slnx -c Release --no-restore
@@ -67,6 +73,7 @@ jobs:
           tags: |
             type=sha,prefix=
             type=raw,value=latest
+            type=raw,value=${{ needs.build.outputs.version }}
 
       - name: Push raindropai-worker
         uses: docker/build-push-action@v6

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Version>0.1.0</Version>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Ajoute `<Version>0.1.0</Version>` dans `Directory.Build.props` (centralisé, comme `TreatWarningsAsErrors`), propagé automatiquement à l'`AssemblyVersion`/`FileVersion` des trois projets.
- Le job `build` de `cd.yml` extrait cette version via `dotnet build -getProperty:Version` et l'expose en output de job.
- Le job `publish` tague l'image `ghcr.io/raindropai-worker` avec cette version en plus de `latest` et du short SHA.

## Test plan
- [x] `dotnet build RaindropAI.slnx -c Release` : build complet réussi
- [x] Vérifié en local que `RaindropAI.Worker.dll` expose bien `FileVersion=0.1.0.0` / `ProductVersion=0.1.0+<sha>`
- [x] `dotnet build src/RaindropAI.Worker/RaindropAI.Worker.csproj -getProperty:Version` renvoie bien `0.1.0`
- [ ] Tag Docker `0.1.0` à valider en conditions réelles au prochain push sur `main` (CD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)