### PR TITLE
fix: force les semantic commits sur les PR Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
-  ]
+  ],
+  "semanticCommits": "enabled"
 }


### PR DESCRIPTION
## Résumé
Renovate a par défaut \`semanticCommits: "auto"\`, qui tente de deviner si le repo utilise les Conventional Commits en inspectant l'historique récent. Comme le repo applique désormais strictement ce format (validé par le check \`Semantic PR\`), on force explicitement \`"semanticCommits": "enabled"\` plutôt que de dépendre de cette détection heuristique.

Comportement par type déjà appliqué par défaut par Renovate en mode semantic commits (pas besoin de le configurer) :
- Mise à jour de dépendance → \`fix(deps): ...\` → déclenche un bump PATCH via Versionize
- Reste (maintenance de lockfile, config Renovate elle-même, etc.) → \`chore: ...\` → pas de release

## Test plan
- [ ] Vérifier que les prochaines PR Renovate ont bien un titre \`fix(deps): ...\` ou \`chore: ...\`
- [ ] Vérifier que le check \`Semantic PR\` passe dessus (types déjà dans la liste autorisée de \`.github/semantic.yml\`)