### PR TITLE
fix: Update renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,12 @@
   "extends": [
     "config:recommended",
     "helpers:pinGitHubActionDigests"
+    ":label(renovate)",
+    ":separateMultipleMajorReleases",
+    ":semanticCommitTypeAll(fix)"
   ],
-  "semanticCommits": "enabled"
+  "prConcurrentLimit": 10,
+  "baseBranchPatterns": [
+    "main"
+  ]
 }

--- a/tests/RaindropAI.Worker.Tests/Services/DigestNotificationJobTests.cs
+++ b/tests/RaindropAI.Worker.Tests/Services/DigestNotificationJobTests.cs
@@ -33,9 +33,9 @@ public class DigestNotificationJobTests
         await CreateJob().Invoke();
 
         await _digestNotifier.Received(1).SendDigestAsync(
-            Arg.Is<IReadOnlyList<ClassifiedArticle>>(a => a.Count == 2), Arg.Any<CancellationToken>());
+            Arg.Is<IReadOnlyList<ClassifiedArticle>>(a => a!.Count == 2), Arg.Any<CancellationToken>());
         await _articleRepository.Received(1).MarkDigestSentAsync(
-            Arg.Is<IReadOnlyCollection<long>>(ids => ids.Contains(1) && ids.Contains(2)),
+            Arg.Is<IReadOnlyCollection<long>>(ids => ids!.Contains(1) && ids!.Contains(2)),
             Arg.Any<DateTimeOffset>(),
             Arg.Any<CancellationToken>());
     }

--- a/tests/RaindropAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
+++ b/tests/RaindropAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
@@ -35,7 +35,7 @@ public class UnsortedClassificationJobTests
 
         await fixture.RaindropClient.Received(1).UpdateRaindropAsync(
             1,
-            Arg.Is<IReadOnlyCollection<string>>(t => t.Count == 2 && t.Contains("Perso") && t.Contains("dotnet")),
+            Arg.Is<IReadOnlyCollection<string>>(t => t!.Count == 2 && t.Contains("Perso") && t.Contains("dotnet")),
             Arg.Any<string>(),
             DotNetCollection.Id,
             Arg.Any<CancellationToken>());
@@ -89,7 +89,7 @@ public class UnsortedClassificationJobTests
         await fixture.RaindropClient.Received(1).UpdateRaindropAsync(
             1,
             Arg.Is<IReadOnlyCollection<string>>(t =>
-                t.Count == 3 && t.Contains("DotNet") && t.Contains("veille") && t.Contains("claude")),
+                t!.Count == 3 && t.Contains("DotNet") && t.Contains("veille") && t.Contains("claude")),
             Arg.Any<string>(),
             null,
             Arg.Any<CancellationToken>());
@@ -155,7 +155,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         await fixture.ArticleRepository.Received(1).UpsertAsync(
-            Arg.Any<RaindropItem>(), Arg.Is<ClassificationResult>(c => c.IsFallback), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+            Arg.Any<RaindropItem>(), Arg.Is<ClassificationResult>(c => c!.IsFallback), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -184,7 +184,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         await fixture.PollingStateRepository.Received(1).UpdateAsync(
-            Arg.Is<PollingState>(s => s.LastRaindropId == 1), Arg.Any<CancellationToken>());
+            Arg.Is<PollingState>(s => s!.LastRaindropId == 1), Arg.Any<CancellationToken>());
         // Le 3e n'est pas traité : reprendre au 2 est la seule façon de ne pas le perdre.
         await fixture.RaindropClient.DidNotReceive().UpdateRaindropAsync(
             3, Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<CancellationToken>());
@@ -214,7 +214,7 @@ public class UnsortedClassificationJobTests
             .WithClassification(CreateClassification(".NET", ["dotnet"]));
 
         fixture.ArticleRepository
-            .UpsertAsync(Arg.Is<RaindropItem>(i => i.Id == 3), Arg.Any<ClassificationResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .UpsertAsync(Arg.Is<RaindropItem>(i => i!.Id == 3), Arg.Any<ClassificationResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("database is locked"));
 
         await fixture.Build().Invoke();
@@ -222,7 +222,7 @@ public class UnsortedClassificationJobTests
         // Avant F-03 l'exception remontait au catch du cycle et le high-water mark n'avançait pas du tout,
         // ce qui rejouait les articles 1 et 2 déjà écrits dans Raindrop.
         await fixture.PollingStateRepository.Received(1).UpdateAsync(
-            Arg.Is<PollingState>(s => s.LastRaindropId == 2), Arg.Any<CancellationToken>());
+            Arg.Is<PollingState>(s => s!.LastRaindropId == 2), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -257,7 +257,7 @@ public class UnsortedClassificationJobTests
         // L'échec de write-back est déjà rattrapé et enregistré ; il ne doit pas bloquer le batch.
         await fixture.ArticleRepository.Received(1).RecordWriteBackAsync(1, false, false, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
         await fixture.PollingStateRepository.Received(1).UpdateAsync(
-            Arg.Is<PollingState>(s => s.LastRaindropId == 2), Arg.Any<CancellationToken>());
+            Arg.Is<PollingState>(s => s!.LastRaindropId == 2), Arg.Any<CancellationToken>());
     }
 
     // --- Notification immédiate ---------------------------------------------------------------
@@ -273,7 +273,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         await fixture.ImmediateNotifier.Received(1).NotifyAsync(
-            Arg.Is<RaindropItem>(i => i.Id == 1), Arg.Any<ClassificationResult>(), Arg.Any<CancellationToken>());
+            Arg.Is<RaindropItem>(i => i!.Id == 1), Arg.Any<ClassificationResult>(), Arg.Any<CancellationToken>());
         await fixture.ArticleRepository.Received(1).MarkDiscordNotifiedAsync(1, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
 
@@ -317,7 +317,7 @@ public class UnsortedClassificationJobTests
             .WithClassification(CreateClassification(".NET", ["dotnet"]));
 
         fixture.Classifier
-            .ClassifyAsync(Arg.Is<RaindropItem>(i => i.Id == 2), Arg.Any<RaindropTaxonomy>(), Arg.Any<CancellationToken>())
+            .ClassifyAsync(Arg.Is<RaindropItem>(i => i!.Id == 2), Arg.Any<RaindropTaxonomy>(), Arg.Any<CancellationToken>())
             .Returns<ClassificationResult>(_ =>
             {
                 cts.Cancel();
@@ -332,7 +332,7 @@ public class UnsortedClassificationJobTests
         // L'écriture du high-water mark ne passe pas par le token d'arrêt, sinon le batch entier
         // serait rejoué au redémarrage.
         await fixture.PollingStateRepository.Received(1).UpdateAsync(
-            Arg.Is<PollingState>(s => s.LastRaindropId == 1), Arg.Any<CancellationToken>());
+            Arg.Is<PollingState>(s => s!.LastRaindropId == 1), Arg.Any<CancellationToken>());
     }
 
     // --- Fixture ------------------------------------------------------------------------------


### PR DESCRIPTION
## Résumé

- Met à jour `renovate.json` : ajoute les préréglages `:label(renovate)`, `:separateMultipleMajorReleases` et `:semanticCommitTypeAll(fix)`, limite le nombre de PR Renovate concurrentes à 10, et restreint explicitement la branche cible à `main`.
- Corrige un échec de build préexistant sur `main`, découvert en poussant cette PR : NSubstitute 6.0.0 annote le paramètre du prédicat de `Arg.Is<T>` comme nullable, ce que `TreatWarningsAsErrors` transformait en erreurs `CS8602`/`CS8604` dans `RaindropAI.Worker.Tests` (`UnsortedClassificationJobTests.cs`, `DigestNotificationJobTests.cs`). Ajout de l'opérateur null-forgiving (`!`) sur la première utilisation du paramètre à chaque site concerné — sans changement de comportement des tests.

## Test plan

- [x] `dotnet build RaindropAI.slnx -c Release` : 0 avertissement, 0 erreur
- [x] `dotnet test RaindropAI.slnx -c Release` : 107 tests passés
- [x] CI GitHub (Build & Test, Docker Build, GitGuardian, Semantic PR) : tous verts