### PR TITLE
fix: bump TargetFramework to net10.0 to match the runtime image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project
 
-RaindropAI is a personal .NET 9 tool that auto-triages the backlog of the **"Non trié"** ("Unsorted", collection id `-1`) collection in Raindrop.io. Each cycle it learns the user's real collections/tags via the Raindrop API, classifies each new unsorted article with Claude Haiku against that learned taxonomy, and writes the result straight back — no human-in-the-loop validation step. Everything outside "Non trié" is considered already sorted by the user and is never touched.
+RaindropAI is a personal .NET 10 tool that auto-triages the backlog of the **"Non trié"** ("Unsorted", collection id `-1`) collection in Raindrop.io. Each cycle it learns the user's real collections/tags via the Raindrop API, classifies each new unsorted article with Claude Haiku against that learned taxonomy, and writes the result straight back — no human-in-the-loop validation step. Everything outside "Non trié" is considered already sorted by the user and is never touched.
 
 Read `docs/adr/` before making architectural changes — decisions and their rationale are recorded there, not duplicated here. Most relevant: [0007](docs/adr/0007-apprentissage-taxonomie-non-trie.md) (learned taxonomy, why manual validation was rejected), [0001](docs/adr/0001-architecture-generale.md) (why this stays a simple 3-project split, not Clean Architecture/CQRS/MediatR), and [0008](docs/adr/0008-versioning-semver-conventional-commits.md) (SemVer versioning via Conventional Commits).
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
 
   <!-- Communes aux cinq projets ; étaient répétées dans chaque .csproj. -->
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,9 +1,14 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Coravel" Version="6.0.2" />
+    <!-- Pin transitif : Microsoft.Data.Sqlite 10.0.10 tire SQLitePCLRaw 2.1.11, qui a une CVE connue
+         (GHSA-2m69-gcr7-jv3q). 2.1.12 la corrige ; pas de version de Microsoft.Data.Sqlite plus récente
+         disponible qui la tire nativement. -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="2.1.12" />
     <PackageVersion Include="Dapper" Version="2.1.79" />
     <PackageVersion Include="MailKit" Version="4.17.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RaindropAI
 
-Outil .NET 9 qui trie automatiquement le backlog de la collection **« Non trié »** de Raindrop.io. Il apprend vos collections et tags réels (via l'API Raindrop), classifie chaque nouvel article avec Claude Haiku en s'appuyant sur cette taxonomie, puis applique directement le résultat : tags fusionnés et déplacement vers la collection identifiée si elle correspond — sans étape de validation manuelle. Une notification Discord signale en plus les articles jugés prioritaires à tester, et un digest email quotidien récapitule tout le reste.
+Outil .NET 10 qui trie automatiquement le backlog de la collection **« Non trié »** de Raindrop.io. Il apprend vos collections et tags réels (via l'API Raindrop), classifie chaque nouvel article avec Claude Haiku en s'appuyant sur cette taxonomie, puis applique directement le résultat : tags fusionnés et déplacement vers la collection identifiée si elle correspond — sans étape de validation manuelle. Une notification Discord signale en plus les articles jugés prioritaires à tester, et un digest email quotidien récapitule tout le reste.
 
 Tout ce qui se trouve **en dehors** de « Non trié » est considéré comme déjà classé par vos soins et n'est jamais retouché.
 
@@ -18,7 +18,7 @@ docs/adr/                      Architecture Decision Records
 
 ## Prérequis
 
-- .NET 9 SDK (dev local)
+- .NET 10 SDK (dev local)
 - Docker + Docker Compose (déploiement, notamment sur Raspberry Pi 64-bit / arm64)
 - Un token API Raindrop.io (App Management Console → Test token)
 - Une clé API Anthropic


### PR DESCRIPTION
## Summary
- Renovate PR #25 bumped `global.json` and the Dockerfile base images to .NET 10 but left `Directory.Build.props` targeting `net9.0`, so the published `ghcr.io/slucky31/raindropai-worker` image ships a net9.0 app on a .NET-10-only runtime — it fails to start (`You must install or update .NET to run this application`), since roll-forward never crosses a major version.
- Bumps `TargetFramework` to `net10.0` and pins `SQLitePCLRaw.lib.e_sqlite3` to `2.1.12` (via central transitive pinning) to clear a known high-severity advisory (GHSA-2m69-gcr7-jv3q) that a fresh net10.0 restore surfaces through `Microsoft.Data.Sqlite` 10.0.10.
- Updates stray ".NET 9" mentions in README.md / CLAUDE.md to .NET 10.

## Test plan
- [x] `dotnet build RaindropAI.slnx` — clean, 0 warnings/errors
- [x] `dotnet test RaindropAI.slnx` — 107/107 passing
- [ ] After merge, CD publishes a new image; redeploy on the Raspberry Pi with `docker compose pull && docker compose up -d` and confirm the worker starts