### PR TITLE
fix: quiet Polly per-attempt logs, add per-item progress log

### DIFF
--- a/src/RaindropAI.Worker/Services/UnsortedClassificationJob.cs
+++ b/src/RaindropAI.Worker/Services/UnsortedClassificationJob.cs
@@ -81,6 +81,11 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
             {
                 try
                 {
+                    if (_logger.IsEnabled(LogLevel.Information))
+                    {
+                        _logger.LogInformation("Traitement du signet {RaindropId} en cours.", item.Id);
+                    }
+
                     var classification = await _classifier.ClassifyAsync(item, taxonomy, cancellationToken);
                     await _articleRepository.UpsertAsync(item, classification, DateTimeOffset.UtcNow, cancellationToken);
 

--- a/src/RaindropAI.Worker/appsettings.json
+++ b/src/RaindropAI.Worker/appsettings.json
@@ -5,7 +5,8 @@
       "Override": {
         "Microsoft": "Warning",
         "System": "Warning",
-        "Microsoft.Hosting.Lifetime": "Information"
+        "Microsoft.Hosting.Lifetime": "Information",
+        "Polly": "Warning"
       }
     },
     "FilePath": "/data/logs/raindropai-.log"


### PR DESCRIPTION
## Summary
- `AddStandardResilienceHandler` (wired on all three HttpClients in `Program.cs`) logs one Information-level "Execution attempt." line per successful HTTP call under the shared Polly logger category (`Polly.Telemetry.TelemetrySource.Name = "Polly"`), which drowned out everything else in `docker compose logs -f` during a large "Non trié" backfill.
- Adds `"Polly": "Warning"` to `Serilog:MinimumLevel:Override` in `src/RaindropAI.Worker/appsettings.json` (prod/Docker config only — `appsettings.Development.json` is untouched so local debugging keeps full detail). Confirmed via Polly source that "Execution attempt." is Information only on first-try success; retry/circuit-breaker/exhausted-retry events log at Warning/Error and stay visible.
- Adds one readable per-item log in `UnsortedClassificationJob.Invoke()`: `Traitement du signet {RaindropId} en cours.`, right before the classification call, so the cycle stays visible without the noise.

## Test plan
- [x] `dotnet build RaindropAI.slnx` — clean
- [x] `dotnet test RaindropAI.slnx` — 107/107 passing
- [ ] After merge/deploy, `sudo docker compose logs -f` shows `Traitement du signet ...` per item instead of `Execution attempt.` spam, while still surfacing any real retry/failure warnings