### PR TITLE
feat: run classification cycle once at startup

### DIFF
--- a/src/RaindropAI.Worker/Program.cs
+++ b/src/RaindropAI.Worker/Program.cs
@@ -84,6 +84,7 @@ try
     {
         scheduler.Schedule<UnsortedClassificationJob>()
             .Cron(workerOptions.PollingCronExpression)
+            .RunOnceAtStart()
             .PreventOverlapping(nameof(UnsortedClassificationJob));
 
         scheduler.Schedule<DigestNotificationJob>()


### PR DESCRIPTION
## Summary
- `UnsortedClassificationJob` only ran on its cron schedule (`Worker__PollingCronExpression`, every 15 min by default), so a fresh `docker compose up -d` gave no signal for up to 15 minutes — painful to verify a deployment actually works.
- Chains Coravel's `.RunOnceAtStart()` onto the existing `.Cron(...)` in `src/RaindropAI.Worker/Program.cs`, so the cycle also fires immediately at host startup, on top of its normal cadence. Confirmed present in the pinned `coravel` 6.0.2 assembly before using it.
- `DigestNotificationJob` is untouched by request — it sends a real email, and firing it on every container restart during testing would be disruptive.
- No double-processing risk: progress is driven by the `PollingState` high-water mark, so a startup run followed by the next cron tick never replays the same items.

## Test plan
- [x] `dotnet build RaindropAI.slnx` — clean
- [x] `dotnet test RaindropAI.slnx` — 107/107 passing
- [ ] After merge/deploy, `sudo docker compose up -d` should show the classification cycle log (`{Count} nouveaux articles à trier` / `Aucun nouvel article...`) immediately, without waiting for the next 15-minute tick