### PR TITLE
feat: journal de cycle et healthcheck Docker (lot 0, PR 3)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,6 @@ Worker__DigestCronExpression=0 7 * * *
 # d'abord les suggestions dans les logs, puis passez a true pour laisser l'outil
 # modifier reellement vos raindrops.
 Worker__WriteBackToRaindrop=false
+# Age maximal (minutes) d'un cycle termine avant que le healthcheck Docker (#35) ne
+# declare le worker en panne. Defaut : 3x le cron de polling par defaut.
+Worker__HealthMaxCycleAgeMinutes=45

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,8 +50,13 @@ Three-project split, dependency direction strictly `Worker → Infrastructure �
    - `Worker__WriteBackToRaindrop=false` disables all of the above (classify + persist + report only) — the one remaining safety switch since there's no per-item human approval.
 5. If `INotificationPolicy.ShouldNotifyImmediately` (default: `Action == ATester && Priority == Haute`), `IImmediateNotifier` (Discord webhook) fires immediately; a send failure is logged but never aborts the batch.
 6. `PollingState` is advanced to the last processed item regardless of individual write-back outcomes.
+7. Exactly one `CycleRun` (`ICycleRunRepository`) is recorded per invocation, cycles with zero new items included — `Ok`/`Empty`/`Interrupted`/`Failed` outcome, item/tag/move/notification counts, failure reason. It's the only signal that the worker is actually alive; a failure to record it is logged but never fails the cycle.
 
 `DigestNotificationJob` (driven by `Worker__DigestCronExpression`, default daily 07:00) sends everything with `EmailDigestSentAtUtc IS NULL` via `IDigestNotifier` (MailKit SMTP), grouped by collection then recommended action — a catch-all so nothing is ever missed even if it didn't trigger a Discord alert.
+
+### Healthcheck
+
+`dotnet LoreAI.Worker.dll --health-check` is a second mode of the same binary, run by Docker's `HEALTHCHECK` (the image is chiseled — no shell, no `curl`). `Program.cs` intercepts `--health-check` right after building the host but before `host.Run()`, so no option outside Postgres/`CycleRuns` needs to be valid for the probe to work. `HealthCheckMode.RunAsync` reads the 3 most recent `CycleRun`s and `Core.Services.HealthEvaluator.IsHealthy` (pure, no I/O) decides: unhealthy if the latest is older than `Worker__HealthMaxCycleAgeMinutes` (default 45) or if the last 3 all have `Outcome == Failed`. Docker Compose won't auto-restart on `unhealthy` (`restart: unless-stopped` only reacts to process death) — this gives visibility (e.g. in Portainer), not automatic recovery.
 
 ### First-run caveat
 

--- a/docs/etat-des-lieux.md
+++ b/docs/etat-des-lieux.md
@@ -4,7 +4,7 @@
 > L'historique est dans `git log` et les Releases. La cible est dans [`roadmap.md`](roadmap.md). Les décisions sont dans [`adr/`](adr/).
 > Le suivi des lots est dans les [issues #41 à #51](https://github.com/slucky31/LoreAI/issues?q=is%3Aissue+milestone%3A*).
 
-**Dernière mise à jour :** 2026-08-23 · **Version publiée :** 0.5.0
+**Dernière mise à jour :** 2026-08-23 · **Version publiée :** 0.6.0
 
 ---
 
@@ -12,10 +12,10 @@
 
 | | |
 |---|---|
-| **Lot en cours** | Lot 0 ([#41](https://github.com/slucky31/LoreAI/issues/41)), **PR 1 mergée et validée en production** ([#53](https://github.com/slucky31/LoreAI/pull/53), v0.5.0) : socle PostgreSQL + EF Core. **PR 2 codée** (branche `feat/lot0-pr2-item-generique-multisource`, pas encore poussée/PR ouverte) : modèle `Item` générique multi-sources ([ADR 0012](adr/0012-modele-item-generique-multi-sources.md)), build + suite de tests (109) verts en local. |
-| **Prochain geste** | Pousser la branche, ouvrir la PR 2, la faire relire puis merger. Ensuite : PR 3 du lot 0 (journal de cycle `CycleRuns` + healthcheck Docker, #35). |
-| **Dernière décision** | **ADR 0012** — `Item` générique remplace `RaindropItem` comme modèle central (D1) ; `RaindropItem` supprimé (pas conservé comme DTO d'adaptateur, `RaindropDto` suffit) ; `PollingState` devient une ligne par source. |
-| **Bloqué par** | Rien. Le Pi (`mcm8`) est en ligne, l'instance PostgreSQL mutualisée provisionnée (base `loreai`, rôles `loreai`/`loreai_ro`) et le worker tourne dessus en production. |
+| **Lot en cours** | Lot 0 ([#41](https://github.com/slucky31/LoreAI/issues/41)), sa **dernière PR**. **PR 1 en production** ([#53](https://github.com/slucky31/LoreAI/pull/53), v0.5.0) : socle PostgreSQL + EF Core. **PR 2 mergée** ([#55](https://github.com/slucky31/LoreAI/pull/55), v0.6.0) : modèle `Item` générique multi-sources ([ADR 0012](adr/0012-modele-item-generique-multi-sources.md)). **PR 3 codée** (branche `feat/lot0-pr3-journal-cycle-healthcheck`, pas encore poussée/PR ouverte) : table `CycleRuns` + healthcheck Docker (#35), build + 132 tests verts en local. Ni la v0.6.0 ni la PR 3 ne sont encore déployées/observées sur `mcm8`. |
+| **Prochain geste** | Pousser la branche PR 3, ouvrir la PR, merger. Puis déployer sur `mcm8` (`sudo docker compose pull && up -d`) — v0.6.0 et PR 3 d'un coup si aucun cycle réel n'a eu lieu entre-temps — et observer un cycle réel + le nouveau `HEALTHCHECK` (visible dans `docker ps`/Portainer). Le lot 0 sera alors complet. |
+| **Dernière décision** | Élargir `IArticleRepository` (`GetByIdAsync`/`GetByFilterAsync`/`SearchAsync`/`CountByAsync`, 4e point de la checklist PR 3 de #41) est **reporté** : aucun consommateur concret avant le MCP du lot 3, signatures non spécifiées — décision explicite pour éviter d'inventer une forme spéculative. |
+| **Bloqué par** | Rien. Le Pi (`mcm8`) est en ligne, l'instance PostgreSQL mutualisée provisionnée (base `loreai`, rôles `loreai`/`loreai_ro`) et le worker tourne dessus en production (sur la version PR 1, pas encore mise à jour). |
 
 ## Ce qui tourne aujourd'hui
 

--- a/src/LoreAI.Core/Enums/CycleOutcome.cs
+++ b/src/LoreAI.Core/Enums/CycleOutcome.cs
@@ -1,0 +1,9 @@
+namespace LoreAI.Core.Enums;
+
+public enum CycleOutcome
+{
+    Ok,
+    Empty,
+    Interrupted,
+    Failed,
+}

--- a/src/LoreAI.Core/Interfaces/ICycleRunRepository.cs
+++ b/src/LoreAI.Core/Interfaces/ICycleRunRepository.cs
@@ -1,0 +1,11 @@
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Interfaces;
+
+public interface ICycleRunRepository
+{
+    Task RecordAsync(CycleRun run, CancellationToken cancellationToken);
+
+    /// <summary>Les cycles les plus récents, du plus récent au plus ancien — alimente le healthcheck.</summary>
+    Task<IReadOnlyList<CycleRun>> GetRecentAsync(int count, CancellationToken cancellationToken);
+}

--- a/src/LoreAI.Core/Models/ClassifiedArticle.cs
+++ b/src/LoreAI.Core/Models/ClassifiedArticle.cs
@@ -6,4 +6,6 @@ public sealed record ClassifiedArticle(
     DateTimeOffset ClassifiedAtUtc,
     bool Moved,
     DateTimeOffset? DiscordNotifiedAtUtc,
-    DateTimeOffset? EmailDigestSentAtUtc);
+    DateTimeOffset? EmailDigestSentAtUtc,
+    DateTimeOffset FetchedAtUtc,
+    string? WriteBackStatus);

--- a/src/LoreAI.Core/Models/CycleRun.cs
+++ b/src/LoreAI.Core/Models/CycleRun.cs
@@ -1,0 +1,19 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Core.Models;
+
+/// <summary>
+/// Une ligne par cycle de <c>UnsortedClassificationJob</c>, cycles vides compris — le seul signal fiable
+/// que le worker tourne (healthcheck, ADR implicite issue #35) et la matière du futur compte-rendu Discord
+/// (issue #31). Écrite une seule fois, en fin de cycle : <see cref="CompletedUtc"/> est donc toujours connu.
+/// </summary>
+public sealed record CycleRun(
+    DateTimeOffset StartedUtc,
+    DateTimeOffset CompletedUtc,
+    CycleOutcome Outcome,
+    int ItemsSeen,
+    int ItemsProcessed,
+    int Moved,
+    int TagsApplied,
+    int Notified,
+    string? FailureReason);

--- a/src/LoreAI.Core/Services/HealthEvaluator.cs
+++ b/src/LoreAI.Core/Services/HealthEvaluator.cs
@@ -1,0 +1,28 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Services;
+
+/// <summary>
+/// Décide si le worker est en vie, à partir des derniers <see cref="CycleRun"/> connus. Pure, testable sans
+/// I/O — même esprit que <c>ClassificationNoteBuilder</c>/<c>DigestMessageBuilder</c>.
+/// </summary>
+public static class HealthEvaluator
+{
+    /// <summary>3 échecs consécutifs, pas 1 : une panne ponctuelle de l'API Raindrop ne doit pas déclencher l'alarme.</summary>
+    private const int ConsecutiveFailuresThreshold = 3;
+
+    public static bool IsHealthy(IReadOnlyList<CycleRun> recentRuns, DateTimeOffset now, TimeSpan maxCycleAge)
+    {
+        if (recentRuns.Count == 0)
+        {
+            return false;
+        }
+
+        var freshEnough = recentRuns[0].CompletedUtc >= now - maxCycleAge;
+        var allRecentFailed = recentRuns.Count >= ConsecutiveFailuresThreshold
+            && recentRuns.Take(ConsecutiveFailuresThreshold).All(r => r.Outcome == CycleOutcome.Failed);
+
+        return freshEnough && !allRecentFailed;
+    }
+}

--- a/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
@@ -165,6 +165,8 @@ public sealed class ArticleRepository : IArticleRepository
             entity.ClassifiedAtUtc ?? DateTimeOffset.UtcNow,
             entity.Moved,
             entity.DiscordNotifiedAtUtc,
-            entity.EmailDigestSentAtUtc);
+            entity.EmailDigestSentAtUtc,
+            entity.FetchedAtUtc,
+            entity.WriteBackStatus);
     }
 }

--- a/src/LoreAI.Infrastructure/Persistence/CycleRunEntity.cs
+++ b/src/LoreAI.Infrastructure/Persistence/CycleRunEntity.cs
@@ -1,0 +1,21 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Infrastructure.Persistence;
+
+/// <summary>
+/// Forme persistée d'un <c>CycleRun</c>. Contrairement à <see cref="ArticleEntity"/>/<see cref="PollingStateEntity"/>,
+/// il n'y a pas de clé applicative (rien n'identifie un cycle a priori) : <see cref="Id"/> est généré par la base.
+/// </summary>
+public sealed class CycleRunEntity
+{
+    public long Id { get; set; }
+    public DateTimeOffset StartedUtc { get; set; }
+    public DateTimeOffset CompletedUtc { get; set; }
+    public CycleOutcome Outcome { get; set; }
+    public int ItemsSeen { get; set; }
+    public int ItemsProcessed { get; set; }
+    public int Moved { get; set; }
+    public int TagsApplied { get; set; }
+    public int Notified { get; set; }
+    public string? FailureReason { get; set; }
+}

--- a/src/LoreAI.Infrastructure/Persistence/CycleRunRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/CycleRunRepository.cs
@@ -1,0 +1,60 @@
+using Microsoft.EntityFrameworkCore;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Infrastructure.Persistence;
+
+public sealed class CycleRunRepository : ICycleRunRepository
+{
+    private readonly IDbContextFactory<LoreAiDbContext> _contextFactory;
+    private readonly PostgresSchemaGuard _schemaGuard;
+
+    public CycleRunRepository(IDbContextFactory<LoreAiDbContext> contextFactory, PostgresSchemaGuard schemaGuard)
+    {
+        _contextFactory = contextFactory;
+        _schemaGuard = schemaGuard;
+    }
+
+    public async Task RecordAsync(CycleRun run, CancellationToken cancellationToken)
+    {
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        context.CycleRuns.Add(new CycleRunEntity
+        {
+            StartedUtc = run.StartedUtc,
+            CompletedUtc = run.CompletedUtc,
+            Outcome = run.Outcome,
+            ItemsSeen = run.ItemsSeen,
+            ItemsProcessed = run.ItemsProcessed,
+            Moved = run.Moved,
+            TagsApplied = run.TagsApplied,
+            Notified = run.Notified,
+            FailureReason = run.FailureReason,
+        });
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<CycleRun>> GetRecentAsync(int count, CancellationToken cancellationToken)
+    {
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entities = await context.CycleRuns
+            .OrderByDescending(c => c.CompletedUtc)
+            .Take(count)
+            .ToListAsync(cancellationToken);
+
+        return entities.Select(e => new CycleRun(
+            e.StartedUtc,
+            e.CompletedUtc,
+            e.Outcome,
+            e.ItemsSeen,
+            e.ItemsProcessed,
+            e.Moved,
+            e.TagsApplied,
+            e.Notified,
+            e.FailureReason)).ToList();
+    }
+}

--- a/src/LoreAI.Infrastructure/Persistence/LoreAiDbContext.cs
+++ b/src/LoreAI.Infrastructure/Persistence/LoreAiDbContext.cs
@@ -6,6 +6,7 @@ public sealed class LoreAiDbContext(DbContextOptions<LoreAiDbContext> options) :
 {
     public DbSet<ArticleEntity> Articles => Set<ArticleEntity>();
     public DbSet<PollingStateEntity> PollingStates => Set<PollingStateEntity>();
+    public DbSet<CycleRunEntity> CycleRuns => Set<CycleRunEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -24,6 +25,13 @@ public sealed class LoreAiDbContext(DbContextOptions<LoreAiDbContext> options) :
         {
             // Une ligne par source (ADR 0012) : la clé naturelle SourceType remplace la ligne unique Id = 1.
             pollingState.HasKey(p => p.SourceType);
+        });
+
+        modelBuilder.Entity<CycleRunEntity>(cycleRun =>
+        {
+            // Pas de clé applicative ici (contrairement à ArticleEntity/PollingStateEntity) : Id est généré.
+            cycleRun.Property(c => c.Outcome).HasConversion<string>();
+            cycleRun.HasIndex(c => c.CompletedUtc);
         });
     }
 }

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260823105956_AddCycleRuns.Designer.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260823105956_AddCycleRuns.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LoreAI.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LoreAI.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(LoreAiDbContext))]
-    partial class LoreAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823105956_AddCycleRuns")]
+    partial class AddCycleRuns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260823105956_AddCycleRuns.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260823105956_AddCycleRuns.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace LoreAI.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCycleRuns : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "CycleRuns",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    StartedUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    CompletedUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Outcome = table.Column<string>(type: "text", nullable: false),
+                    ItemsSeen = table.Column<int>(type: "integer", nullable: false),
+                    ItemsProcessed = table.Column<int>(type: "integer", nullable: false),
+                    Moved = table.Column<int>(type: "integer", nullable: false),
+                    TagsApplied = table.Column<int>(type: "integer", nullable: false),
+                    Notified = table.Column<int>(type: "integer", nullable: false),
+                    FailureReason = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CycleRuns", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CycleRuns_CompletedUtc",
+                table: "CycleRuns",
+                column: "CompletedUtc");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "CycleRuns");
+        }
+    }
+}

--- a/src/LoreAI.Worker/Dockerfile
+++ b/src/LoreAI.Worker/Dockerfile
@@ -40,3 +40,8 @@ VOLUME ["/data"]
 # de base non chiselée ferait silencieusement retomber le worker en root.
 USER $APP_UID
 ENTRYPOINT ["dotnet", "LoreAI.Worker.dll"]
+
+# Image chiselée : ni shell ni curl, donc pas de `CMD curl ...` possible — la sonde est le worker
+# lui-même, en forme exec (#35). Intervalle à 5 min : chaque sonde démarre un second processus .NET.
+HEALTHCHECK --interval=5m --timeout=10s --start-period=30s \
+    CMD ["dotnet", "LoreAI.Worker.dll", "--health-check"]

--- a/src/LoreAI.Worker/HealthCheckMode.cs
+++ b/src/LoreAI.Worker/HealthCheckMode.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Options;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Services;
+using LoreAI.Worker.Options;
+
+namespace LoreAI.Worker;
+
+/// <summary>
+/// Sonde `--health-check` (#35) : un second processus .NET, démarré par Docker toutes les 5 min sur une
+/// image chiselée sans shell ni curl (cf. roadmap, « Ce que O2 peut et ne peut pas faire »). Réutilise le
+/// même <see cref="IServiceProvider"/> que le worker normal — construit par <c>Program.cs</c> sans jamais
+/// appeler <c>host.Run()</c>, donc sans déclencher la validation des options non liées à Postgres/CycleRuns.
+/// </summary>
+public static class HealthCheckMode
+{
+    private const int RecentRunsToInspect = 3;
+
+    public static async Task<bool> RunAsync(IServiceProvider services, CancellationToken cancellationToken)
+    {
+        var cycleRunRepository = services.GetRequiredService<ICycleRunRepository>();
+        var workerOptions = services.GetRequiredService<IOptions<WorkerOptions>>().Value;
+
+        var recentRuns = await cycleRunRepository.GetRecentAsync(RecentRunsToInspect, cancellationToken);
+
+        return HealthEvaluator.IsHealthy(recentRuns, DateTimeOffset.UtcNow, TimeSpan.FromMinutes(workerOptions.HealthMaxCycleAgeMinutes));
+    }
+}

--- a/src/LoreAI.Worker/Options/WorkerOptions.cs
+++ b/src/LoreAI.Worker/Options/WorkerOptions.cs
@@ -19,4 +19,11 @@ public sealed class WorkerOptions
     /// seulement, sans toucher à Raindrop).
     /// </summary>
     public bool WriteBackToRaindrop { get; init; } = true;
+
+    /// <summary>
+    /// Âge maximal (en minutes) d'un cycle terminé avant que le healthcheck Docker (#35) ne considère le
+    /// worker en panne. Défaut : 3× le cron par défaut (15 min), pour absorber un cycle occasionnellement lent.
+    /// </summary>
+    [Range(1, int.MaxValue)]
+    public int HealthMaxCycleAgeMinutes { get; init; } = 45;
 }

--- a/src/LoreAI.Worker/Program.cs
+++ b/src/LoreAI.Worker/Program.cs
@@ -59,6 +59,7 @@ try
     builder.Services.AddHostedService<PostgresSchemaInitializer>();
     builder.Services.AddSingleton<IArticleRepository, ArticleRepository>();
     builder.Services.AddSingleton<IPollingStateRepository, PollingStateRepository>();
+    builder.Services.AddSingleton<ICycleRunRepository, CycleRunRepository>();
     // DefaultNotificationPolicy expose des seuils en paramètres de constructeur ; ils étaient annoncés
     // « injectables » mais aucun appelant ne les fournissait. On les alimente depuis la configuration ici,
     // plutôt que de faire dépendre Core de Microsoft.Extensions.Options.
@@ -86,6 +87,14 @@ try
     builder.Services.AddTransient<DigestNotificationJob>();
 
     var host = builder.Build();
+
+    // Sonde Docker (#35) : un second processus .NET, sans jamais atteindre host.Run() ni la validation des
+    // options non liées (Raindrop/Classifier/Discord/Email peuvent être absentes d'une sonde). Voir HealthCheckMode.
+    if (args.Contains("--health-check"))
+    {
+        Environment.ExitCode = await LoreAI.Worker.HealthCheckMode.RunAsync(host.Services, CancellationToken.None) ? 0 : 1;
+        return;
+    }
 
     var workerOptions = host.Services.GetRequiredService<IOptions<WorkerOptions>>().Value;
     host.Services.UseScheduler(scheduler =>

--- a/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
+++ b/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
@@ -20,6 +20,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
     private readonly IRaindropClient _raindropClient;
     private readonly IPollingStateRepository _pollingStateRepository;
     private readonly IArticleRepository _articleRepository;
+    private readonly ICycleRunRepository _cycleRunRepository;
     private readonly IClassifier _classifier;
     private readonly IImmediateNotifier _immediateNotifier;
     private readonly INotificationPolicy _notificationPolicy;
@@ -30,6 +31,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
         IRaindropClient raindropClient,
         IPollingStateRepository pollingStateRepository,
         IArticleRepository articleRepository,
+        ICycleRunRepository cycleRunRepository,
         IClassifier classifier,
         IImmediateNotifier immediateNotifier,
         INotificationPolicy notificationPolicy,
@@ -39,6 +41,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
         _raindropClient = raindropClient;
         _pollingStateRepository = pollingStateRepository;
         _articleRepository = articleRepository;
+        _cycleRunRepository = cycleRunRepository;
         _classifier = classifier;
         _immediateNotifier = immediateNotifier;
         _notificationPolicy = notificationPolicy;
@@ -52,11 +55,21 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
     public async Task Invoke()
     {
         var cancellationToken = CancellationToken;
+        var startedUtc = DateTimeOffset.UtcNow;
+
+        var itemsSeen = 0;
+        var processedCount = 0;
+        var movedCount = 0;
+        var tagsAppliedCount = 0;
+        var notifiedCount = 0;
+        string? failureReason = null;
+        CycleOutcome? forcedOutcome = null;
 
         try
         {
             var lastState = await _pollingStateRepository.GetAsync(SourceType.Raindrop, cancellationToken);
             var newItems = await _raindropClient.GetNewItemsAsync(lastState, cancellationToken);
+            itemsSeen = newItems.Count;
 
             if (newItems.Count == 0)
             {
@@ -74,9 +87,6 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
                     taxonomy.Tags.Count);
             }
 
-            var notifiedCount = 0;
-            var movedCount = 0;
-            var processedCount = 0;
             Item? lastProcessed = null;
 
             foreach (var item in newItems)
@@ -96,6 +106,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
                         // Le repli n'est pas une décision du modèle : l'appliquer écrirait une trace d'erreur
                         // dans le raindrop réel. On interrompt le cycle sans dépasser cet article, pour qu'il
                         // soit repris au prochain passage au lieu d'être perdu définitivement par le high-water mark.
+                        failureReason = $"Classification en repli pour l'item {item.SourceId} ({classification.Reason}).";
                         _logger.LogWarning(
                             "Classification en repli pour l'item {SourceId} ({Reason}) — rien n'est appliqué, cycle interrompu, reprise au prochain passage.",
                             item.SourceId,
@@ -107,11 +118,12 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
 
                     if (_options.WriteBackToRaindrop)
                     {
-                        var moved = await ApplyClassificationAsync(item, classification, matchedCollection, cancellationToken);
-                        if (moved)
+                        var writeBack = await ApplyClassificationAsync(item, classification, matchedCollection, cancellationToken);
+                        if (writeBack.Moved)
                         {
                             movedCount++;
                         }
+                        tagsAppliedCount += writeBack.TagsAdded;
                     }
 
                     if (_notificationPolicy.ShouldNotifyImmediately(classification))
@@ -126,6 +138,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
+                    failureReason = $"Arrêt de l'application demandé avant l'item {item.SourceId}.";
                     if (_logger.IsEnabled(LogLevel.Information))
                     {
                         _logger.LogInformation(
@@ -139,6 +152,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
                     // Sans ce filet, l'exception remontait au catch du cycle et court-circuitait l'avancement
                     // du high-water mark : les articles déjà traités et écrits dans Raindrop étaient rejoués
                     // au cycle suivant. On s'arrête ici en conservant la progression acquise.
+                    failureReason = ex.Message;
                     _logger.LogError(
                         ex,
                         "Échec du traitement de l'item {SourceId} — cycle interrompu, la progression acquise est conservée.",
@@ -169,11 +183,44 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
+            forcedOutcome = CycleOutcome.Interrupted;
+            failureReason ??= "Cycle de classification interrompu par l'arrêt de l'application.";
             _logger.LogInformation("Cycle de classification interrompu par l'arrêt de l'application.");
         }
         catch (Exception ex)
         {
+            // itemsSeen == 0 ici signifie qu'on ne sait même pas s'il y avait quelque chose à traiter
+            // (échec avant/pendant GetNewItemsAsync) : Failed. Au-delà, l'existence des items est connue,
+            // l'échec n'a fait qu'interrompre leur traitement : Interrupted.
+            forcedOutcome = itemsSeen == 0 ? CycleOutcome.Failed : CycleOutcome.Interrupted;
+            failureReason ??= ex.Message;
             _logger.LogError(ex, "Échec du cycle de classification de \"Non trié\".");
+        }
+        finally
+        {
+            var outcome = forcedOutcome ?? (itemsSeen == 0
+                ? CycleOutcome.Empty
+                : (processedCount == itemsSeen ? CycleOutcome.Ok : CycleOutcome.Interrupted));
+
+            var run = new CycleRun(
+                startedUtc,
+                DateTimeOffset.UtcNow,
+                outcome,
+                itemsSeen,
+                processedCount,
+                movedCount,
+                tagsAppliedCount,
+                notifiedCount,
+                failureReason);
+
+            try
+            {
+                await _cycleRunRepository.RecordAsync(run, CancellationToken.None);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Échec de l'enregistrement du journal de cycle.");
+            }
         }
     }
 
@@ -214,7 +261,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
     /// correspondance existante a été trouvée. La note rédigée par l'utilisateur est préservée ; seul le
     /// bloc [LoreAI] d'un passage précédent est remplacé (cf. <see cref="ClassificationNoteBuilder"/>).
     /// </summary>
-    private async Task<bool> ApplyClassificationAsync(
+    private async Task<WriteBackOutcome> ApplyClassificationAsync(
         Item item,
         ClassificationResult classification,
         RaindropCollection? matchedCollection,
@@ -234,16 +281,21 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
             await _raindropClient.UpdateRaindropAsync(raindropId, mergedTags, mergedNote, matchedCollection?.Id, cancellationToken);
             await _articleRepository.RecordWriteBackAsync(raindropId, success: true, moved: matchedCollection is not null, DateTimeOffset.UtcNow, cancellationToken);
 
-            return matchedCollection is not null;
+            // Ne compte que les tags réellement nouveaux (fusion insensible à la casse) : un tag déjà
+            // présent sur l'article ne doit pas gonfler le compteur du journal de cycle.
+            var tagsAdded = mergedTags.Count - item.Tags.Count;
+            return new WriteBackOutcome(matchedCollection is not null, tagsAdded);
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Échec de l'application des tags/déplacement pour l'item {SourceId}", item.SourceId);
             await _articleRepository.RecordWriteBackAsync(raindropId, success: false, moved: false, DateTimeOffset.UtcNow, cancellationToken);
-            return false;
+            return new WriteBackOutcome(Moved: false, TagsAdded: 0);
         }
     }
 
     /// <summary>Le write-back reste strictement Raindrop (ADR 0012) : on retrouve l'id numérique attendu par l'API.</summary>
     private static long ParseRaindropId(Item item) => long.Parse(item.SourceId, CultureInfo.InvariantCulture);
+
+    private readonly record struct WriteBackOutcome(bool Moved, int TagsAdded);
 }

--- a/tests/LoreAI.Core.Tests/Services/HealthEvaluatorTests.cs
+++ b/tests/LoreAI.Core.Tests/Services/HealthEvaluatorTests.cs
@@ -1,0 +1,93 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Core.Services;
+
+namespace LoreAI.Core.Tests.Services;
+
+public class HealthEvaluatorTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.Parse("2026-08-23T12:00:00Z", System.Globalization.CultureInfo.InvariantCulture);
+    private static readonly TimeSpan MaxAge = TimeSpan.FromMinutes(45);
+
+    [Fact]
+    public void IsHealthy_NoRuns_ReturnsFalse()
+    {
+        Assert.False(HealthEvaluator.IsHealthy([], Now, MaxAge));
+    }
+
+    [Fact]
+    public void IsHealthy_RecentOkRun_ReturnsTrue()
+    {
+        var runs = new[] { CreateRun(Now.AddMinutes(-5), CycleOutcome.Ok) };
+
+        Assert.True(HealthEvaluator.IsHealthy(runs, Now, MaxAge));
+    }
+
+    [Fact]
+    public void IsHealthy_StaleLastRun_ReturnsFalse()
+    {
+        var runs = new[] { CreateRun(Now.AddMinutes(-46), CycleOutcome.Ok) };
+
+        Assert.False(HealthEvaluator.IsHealthy(runs, Now, MaxAge));
+    }
+
+    [Fact]
+    public void IsHealthy_ExactlyAtThreshold_ReturnsTrue()
+    {
+        var runs = new[] { CreateRun(Now.AddMinutes(-45), CycleOutcome.Ok) };
+
+        Assert.True(HealthEvaluator.IsHealthy(runs, Now, MaxAge));
+    }
+
+    [Fact]
+    public void IsHealthy_SingleFailedRun_ReturnsTrue()
+    {
+        // Une panne ponctuelle de l'API Raindrop ne doit pas déclencher l'alarme — il faut 3 échecs de suite.
+        var runs = new[] { CreateRun(Now.AddMinutes(-1), CycleOutcome.Failed) };
+
+        Assert.True(HealthEvaluator.IsHealthy(runs, Now, MaxAge));
+    }
+
+    [Fact]
+    public void IsHealthy_ThreeConsecutiveFailures_ReturnsFalse()
+    {
+        var runs = new[]
+        {
+            CreateRun(Now.AddMinutes(-1), CycleOutcome.Failed),
+            CreateRun(Now.AddMinutes(-16), CycleOutcome.Failed),
+            CreateRun(Now.AddMinutes(-31), CycleOutcome.Failed),
+        };
+
+        Assert.False(HealthEvaluator.IsHealthy(runs, Now, MaxAge));
+    }
+
+    [Fact]
+    public void IsHealthy_TwoFailuresThenAnOk_ReturnsTrue()
+    {
+        // Le plus récent d'abord (contrat de GetRecentAsync) : un succès récent efface les échecs précédents.
+        var runs = new[]
+        {
+            CreateRun(Now.AddMinutes(-1), CycleOutcome.Ok),
+            CreateRun(Now.AddMinutes(-16), CycleOutcome.Failed),
+            CreateRun(Now.AddMinutes(-31), CycleOutcome.Failed),
+        };
+
+        Assert.True(HealthEvaluator.IsHealthy(runs, Now, MaxAge));
+    }
+
+    [Fact]
+    public void IsHealthy_EmptyCyclesAreNotFailures_ReturnsTrue()
+    {
+        var runs = new[]
+        {
+            CreateRun(Now.AddMinutes(-1), CycleOutcome.Empty),
+            CreateRun(Now.AddMinutes(-16), CycleOutcome.Empty),
+            CreateRun(Now.AddMinutes(-31), CycleOutcome.Empty),
+        };
+
+        Assert.True(HealthEvaluator.IsHealthy(runs, Now, MaxAge));
+    }
+
+    private static CycleRun CreateRun(DateTimeOffset completedUtc, CycleOutcome outcome) =>
+        new(completedUtc.AddMinutes(-1), completedUtc, outcome, 0, 0, 0, 0, 0, null);
+}

--- a/tests/LoreAI.Infrastructure.Tests/Notifications/DigestMessageBuilderTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Notifications/DigestMessageBuilderTests.cs
@@ -113,7 +113,7 @@ public class DigestMessageBuilderTests
         var item = CreateItem(title, "https://example.com");
         var classification = new ClassificationResult(suggestedCollection, tags, action, priority, "raison", "model", "raw");
 
-        return new ClassifiedArticle(item, classification, DateTimeOffset.UtcNow, Moved: suggestedCollection is not null, null, null);
+        return new ClassifiedArticle(item, classification, DateTimeOffset.UtcNow, Moved: suggestedCollection is not null, null, null, DateTimeOffset.UtcNow, null);
     }
 
     private static Item CreateItem(string title, string link) => new(

--- a/tests/LoreAI.Infrastructure.Tests/Persistence/CycleRunRepositoryTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Persistence/CycleRunRepositoryTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Infrastructure.Persistence;
+
+namespace LoreAI.Infrastructure.Tests.Persistence;
+
+[Collection("Postgres")]
+public class CycleRunRepositoryTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fixture;
+    private readonly CycleRunRepository _repository;
+
+    public CycleRunRepositoryTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+        _repository = new CycleRunRepository(fixture.ContextFactory, new PostgresSchemaGuard(fixture.ContextFactory));
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var context = _fixture.CreateContext();
+        await context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE \"CycleRuns\" RESTART IDENTITY CASCADE");
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task GetRecentAsync_NoRuns_ReturnsEmpty()
+    {
+        var runs = await _repository.GetRecentAsync(3, TestContext.Current.CancellationToken);
+
+        Assert.Empty(runs);
+    }
+
+    [Fact]
+    public async Task RecordAsync_ThenGetRecentAsync_RoundTripsValues()
+    {
+        var run = new CycleRun(
+            DateTimeOffset.Parse("2026-08-23T12:00:00Z", System.Globalization.CultureInfo.InvariantCulture),
+            DateTimeOffset.Parse("2026-08-23T12:00:05Z", System.Globalization.CultureInfo.InvariantCulture),
+            CycleOutcome.Ok,
+            ItemsSeen: 3,
+            ItemsProcessed: 3,
+            Moved: 2,
+            TagsApplied: 5,
+            Notified: 1,
+            FailureReason: null);
+
+        await _repository.RecordAsync(run, TestContext.Current.CancellationToken);
+        var recent = await _repository.GetRecentAsync(3, TestContext.Current.CancellationToken);
+
+        var single = Assert.Single(recent);
+        Assert.Equal(run, single);
+    }
+
+    [Fact]
+    public async Task GetRecentAsync_ReturnsMostRecentCompletedFirst()
+    {
+        await _repository.RecordAsync(CreateRun(DateTimeOffset.UtcNow.AddMinutes(-30), CycleOutcome.Failed), TestContext.Current.CancellationToken);
+        await _repository.RecordAsync(CreateRun(DateTimeOffset.UtcNow.AddMinutes(-15), CycleOutcome.Empty), TestContext.Current.CancellationToken);
+        await _repository.RecordAsync(CreateRun(DateTimeOffset.UtcNow, CycleOutcome.Ok), TestContext.Current.CancellationToken);
+
+        var recent = await _repository.GetRecentAsync(2, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, recent.Count);
+        Assert.Equal(CycleOutcome.Ok, recent[0].Outcome);
+        Assert.Equal(CycleOutcome.Empty, recent[1].Outcome);
+    }
+
+    private static CycleRun CreateRun(DateTimeOffset completedUtc, CycleOutcome outcome) =>
+        new(completedUtc.AddSeconds(-5), completedUtc, outcome, 0, 0, 0, 0, 0, null);
+}

--- a/tests/LoreAI.Worker.Tests/Services/DigestNotificationJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/DigestNotificationJobTests.cs
@@ -68,6 +68,6 @@ public class DigestNotificationJobTests
         var classification = new ClassificationResult(
             ".NET", ["dotnet"], RecommendedAction.ALire, Priority.Moyenne, "raison", "model", "{}");
 
-        return new ClassifiedArticle(item, classification, DateTimeOffset.UtcNow, Moved: true, null, null);
+        return new ClassifiedArticle(item, classification, DateTimeOffset.UtcNow, Moved: true, null, null, DateTimeOffset.UtcNow, null);
     }
 }

--- a/tests/LoreAI.Worker.Tests/Services/HealthCheckModeTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/HealthCheckModeTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.Extensions.DependencyInjection;
+using NSubstitute;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+using LoreAI.Worker;
+using LoreAI.Worker.Options;
+
+// LoreAI.Worker.Options masque Microsoft.Extensions.Options dans ce fichier.
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace LoreAI.Worker.Tests.Services;
+
+public class HealthCheckModeTests
+{
+    [Fact]
+    public async Task RunAsync_RecentOkRun_ReturnsTrue()
+    {
+        var services = BuildServices(
+            [new CycleRun(DateTimeOffset.UtcNow.AddMinutes(-1), DateTimeOffset.UtcNow.AddMinutes(-1), CycleOutcome.Ok, 1, 1, 0, 0, 0, null)],
+            healthMaxCycleAgeMinutes: 45);
+
+        var healthy = await HealthCheckMode.RunAsync(services, TestContext.Current.CancellationToken);
+
+        Assert.True(healthy);
+    }
+
+    [Fact]
+    public async Task RunAsync_NoRuns_ReturnsFalse()
+    {
+        var services = BuildServices([], healthMaxCycleAgeMinutes: 45);
+
+        var healthy = await HealthCheckMode.RunAsync(services, TestContext.Current.CancellationToken);
+
+        Assert.False(healthy);
+    }
+
+    [Fact]
+    public async Task RunAsync_StaleLastRun_ReturnsFalse()
+    {
+        var services = BuildServices(
+            [new CycleRun(DateTimeOffset.UtcNow.AddMinutes(-90), DateTimeOffset.UtcNow.AddMinutes(-90), CycleOutcome.Ok, 1, 1, 0, 0, 0, null)],
+            healthMaxCycleAgeMinutes: 45);
+
+        var healthy = await HealthCheckMode.RunAsync(services, TestContext.Current.CancellationToken);
+
+        Assert.False(healthy);
+    }
+
+    [Fact]
+    public async Task RunAsync_UsesConfiguredMaxCycleAge()
+    {
+        var runAt = DateTimeOffset.UtcNow.AddMinutes(-20);
+        var services = BuildServices(
+            [new CycleRun(runAt, runAt, CycleOutcome.Ok, 1, 1, 0, 0, 0, null)],
+            healthMaxCycleAgeMinutes: 10);
+
+        var healthy = await HealthCheckMode.RunAsync(services, TestContext.Current.CancellationToken);
+
+        Assert.False(healthy);
+    }
+
+    [Fact]
+    public async Task RunAsync_RequestsExactlyThreeRecentRuns()
+    {
+        var cycleRunRepository = Substitute.For<ICycleRunRepository>();
+        cycleRunRepository.GetRecentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
+        var services = new ServiceCollection()
+            .AddSingleton(cycleRunRepository)
+            .AddSingleton(MsOptions.Create(new WorkerOptions { HealthMaxCycleAgeMinutes = 45 }))
+            .BuildServiceProvider();
+
+        await HealthCheckMode.RunAsync(services, TestContext.Current.CancellationToken);
+
+        await cycleRunRepository.Received(1).GetRecentAsync(3, Arg.Any<CancellationToken>());
+    }
+
+    private static ServiceProvider BuildServices(IReadOnlyList<CycleRun> recentRuns, int healthMaxCycleAgeMinutes)
+    {
+        var cycleRunRepository = Substitute.For<ICycleRunRepository>();
+        cycleRunRepository.GetRecentAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(recentRuns);
+
+        return new ServiceCollection()
+            .AddSingleton(cycleRunRepository)
+            .AddSingleton(MsOptions.Create(new WorkerOptions { HealthMaxCycleAgeMinutes = healthMaxCycleAgeMinutes }))
+            .BuildServiceProvider();
+    }
+}

--- a/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
@@ -335,6 +335,139 @@ public class UnsortedClassificationJobTests
             Arg.Is<PollingState>(s => s!.LastSourceItemId == "1"), Arg.Any<CancellationToken>());
     }
 
+    // --- Journal de cycle (CycleRuns) -----------------------------------------------------------
+
+    [Fact]
+    public async Task Invoke_NoNewItems_RecordsEmptyOutcome()
+    {
+        var fixture = new JobFixture().WithNewItems();
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleRunRepository.Received(1).RecordAsync(
+            Arg.Is<CycleRun>(r => r!.Outcome == CycleOutcome.Empty && r.ItemsSeen == 0),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_AllItemsProcessed_RecordsOkOutcomeWithCounts()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1, tags: ["dotnet"]), CreateItem(2))
+            .WithClassification(CreateClassification(".NET", ["dotnet", "claude"]));
+        fixture.NotificationPolicy.ShouldNotifyImmediately(Arg.Any<ClassificationResult>()).Returns(true);
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleRunRepository.Received(1).RecordAsync(
+            Arg.Is<CycleRun>(r =>
+                r!.Outcome == CycleOutcome.Ok
+                && r.ItemsSeen == 2
+                && r.ItemsProcessed == 2
+                && r.Moved == 2
+                // Item 1 a déjà "dotnet" : seul "claude" est nouveau (1). Item 2 n'a rien : les deux sont nouveaux (2).
+                && r.TagsApplied == 3
+                && r.Notified == 2
+                && r.FailureReason == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_FallbackClassification_RecordsInterruptedOutcomeWithReason()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1), CreateItem(2))
+            .WithClassification(ClassificationResult.Fallback("model", "Classification échouée: 429", "{}"));
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleRunRepository.Received(1).RecordAsync(
+            Arg.Is<CycleRun>(r =>
+                r!.Outcome == CycleOutcome.Interrupted
+                && r.ItemsSeen == 2
+                && r.ItemsProcessed == 0
+                && r.FailureReason != null && r.FailureReason.Contains("repli", StringComparison.Ordinal)),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_ExceptionOnItem_RecordsInterruptedOutcome()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1), CreateItem(2))
+            .WithClassification(CreateClassification(".NET", ["dotnet"]));
+        fixture.ArticleRepository
+            .UpsertAsync(Arg.Is<Item>(i => i!.SourceId == "1"), Arg.Any<ClassificationResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("database is locked"));
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleRunRepository.Received(1).RecordAsync(
+            Arg.Is<CycleRun>(r =>
+                r!.Outcome == CycleOutcome.Interrupted
+                && r.ItemsSeen == 2
+                && r.ItemsProcessed == 0
+                && r.FailureReason == "database is locked"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_RaindropUnavailable_RecordsFailedOutcome()
+    {
+        var fixture = new JobFixture();
+        fixture.RaindropClient
+            .GetNewItemsAsync(Arg.Any<PollingState>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("401 Unauthorized"));
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleRunRepository.Received(1).RecordAsync(
+            Arg.Is<CycleRun>(r => r!.Outcome == CycleOutcome.Failed && r.ItemsSeen == 0 && r.FailureReason == "401 Unauthorized"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_CancelledDuringBatch_RecordsInterruptedOutcome()
+    {
+        using var cts = new CancellationTokenSource();
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1), CreateItem(2))
+            .WithClassification(CreateClassification(".NET", ["dotnet"]));
+
+        fixture.Classifier
+            .ClassifyAsync(Arg.Is<Item>(i => i!.SourceId == "2"), Arg.Any<RaindropTaxonomy>(), Arg.Any<CancellationToken>())
+            .Returns<ClassificationResult>(_ =>
+            {
+                cts.Cancel();
+                throw new OperationCanceledException(cts.Token);
+            });
+
+        var job = fixture.Build();
+        job.CancellationToken = cts.Token;
+
+        await job.Invoke();
+
+        await fixture.CycleRunRepository.Received(1).RecordAsync(
+            Arg.Is<CycleRun>(r => r!.Outcome == CycleOutcome.Interrupted && r.ItemsSeen == 2 && r.ItemsProcessed == 1),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>L'échec de l'écriture du journal lui-même est un détail d'observabilité : jamais fatal au cycle.</summary>
+    [Fact]
+    public async Task Invoke_CycleRunRecordingFails_DoesNotThrow()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1))
+            .WithClassification(CreateClassification(".NET", ["dotnet"]));
+        fixture.CycleRunRepository
+            .RecordAsync(Arg.Any<CycleRun>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("database is locked"));
+
+        var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());
+
+        Assert.Null(exception);
+    }
+
     // --- Fixture ------------------------------------------------------------------------------
 
     private static Item CreateItem(long id, IReadOnlyList<string>? tags = null) => new(
@@ -358,6 +491,7 @@ public class UnsortedClassificationJobTests
         public IRaindropClient RaindropClient { get; } = Substitute.For<IRaindropClient>();
         public IPollingStateRepository PollingStateRepository { get; } = Substitute.For<IPollingStateRepository>();
         public IArticleRepository ArticleRepository { get; } = Substitute.For<IArticleRepository>();
+        public ICycleRunRepository CycleRunRepository { get; } = Substitute.For<ICycleRunRepository>();
         public IClassifier Classifier { get; } = Substitute.For<IClassifier>();
         public IImmediateNotifier ImmediateNotifier { get; } = Substitute.For<IImmediateNotifier>();
         public INotificationPolicy NotificationPolicy { get; } = Substitute.For<INotificationPolicy>();
@@ -409,6 +543,7 @@ public class UnsortedClassificationJobTests
             RaindropClient,
             PollingStateRepository,
             ArticleRepository,
+            CycleRunRepository,
             Classifier,
             ImmediateNotifier,
             NotificationPolicy,


### PR DESCRIPTION
## Résumé

PR 3 du lot 0 ([#41](https://github.com/slucky31/LoreAI/issues/41)), la dernière — après la PR 1 (socle PostgreSQL/EF Core, v0.5.0) et la PR 2 (modèle `Item` générique, [ADR 0012](docs/adr/0012-modele-item-generique-multi-sources.md), v0.6.0).

- **Table `CycleRuns`** (`Core.CycleRun` / `ICycleRunRepository`) : une ligne par cycle de `UnsortedClassificationJob`, cycles vides compris — le premier signal fiable que le worker tourne ([F-10](docs/audit/2026-08-01-audit-code.md), jamais livré jusqu'ici). `Outcome` (`Ok`/`Empty`/`Interrupted`/`Failed`) et compteurs (items vus/traités/déplacés/tags appliqués/notifiés) calculés **après coup**, à partir des compteurs et chemins d'erreur déjà en place, pour ne pas réécrire la logique existante ni casser les tests sur les cas d'erreur (repli, exception par item, annulation, Raindrop injoignable).
- **Healthcheck Docker** ([#35](https://github.com/slucky31/LoreAI/issues/35)) : mode `dotnet LoreAI.Worker.dll --health-check`, intercepté dans `Program.cs` juste avant `host.Run()` — réutilise le même host déjà construit (même mécanisme que `dotnet ef`), sans déclencher la validation des options non liées à Postgres/`CycleRuns`. `Core.Services.HealthEvaluator` (pur, sans I/O) décide : unhealthy si aucun cycle terminé depuis `Worker__HealthMaxCycleAgeMinutes` (défaut 45) ou si les 3 derniers cycles ont tous `Outcome == Failed` (une panne ponctuelle ne déclenche pas l'alarme). `HEALTHCHECK` en forme exec dans le `Dockerfile` (image chiselée, ni shell ni `curl`).
- `ClassifiedArticle` ne jette plus `FetchedAtUtc`/`WriteBackStatus` (déjà persistés, jamais reportés jusqu'ici).
- **Reporté explicitement** (décision prise avant de coder) : élargir `IArticleRepository` (`GetByIdAsync`/`GetByFilterAsync`/`SearchAsync`/`CountByAsync`, 4e point de la checklist PR 3 de #41) — aucun consommateur concret avant le MCP du lot 3, signatures non spécifiées par la roadmap.

## Test plan

- [x] `dotnet build LoreAI.slnx` — 0 warning (`TreatWarningsAsErrors`)
- [x] `dotnet test LoreAI.slnx` — 132/132 verts (23 nouveaux : `HealthEvaluatorTests`, `CycleRunRepositoryTests`, `HealthCheckModeTests`, nouveaux scénarios `UnsortedClassificationJobTests`)
- [x] Migration `AddCycleRuns` relue — table neuve, pas de risque de perte de données (contrairement à la PR 2)
- [ ] Déploiement sur `mcm8` et observation d'un cycle réel + du nouveau `HEALTHCHECK` (Portainer/`docker ps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD9QVSMUUkykAme7rp9Bqa