### PR TITLE
feat: indexation en lecture seule de la bibliothèque Raindrop (lot 1, #42)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,3 +42,9 @@ Worker__WriteBackToRaindrop=false
 # Age maximal (minutes) d'un cycle termine avant que le healthcheck Docker (#35) ne
 # declare le worker en panne. Defaut : 3x le cron de polling par defaut.
 Worker__HealthMaxCycleAgeMinutes=45
+# Indexation en lecture seule de toute la bibliotheque Raindrop (lot 1, #42) : declenchement
+# rare (defaut chaque dimanche 3h UTC), jamais de classification ni d'ecriture chez Raindrop.
+Worker__LibraryIndexCronExpression=0 3 * * 0
+# A true pour lancer aussi une passe au demarrage du worker (soumise a une garde de 24h :
+# ignoree si la derniere passe complete date de moins de 24h).
+Worker__IndexLibraryOnStartup=false

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ VALUES ('Raindrop', '<id_du_dernier_raindrop_a_ignorer>', '<date_ISO8601_UTC>', 
 
 `Worker__WriteBackToRaindrop=false` désactive cette application automatique (mode classification + rapport seulement, rien n'est modifié dans Raindrop) — utile pour observer le comportement avant de laisser l'outil toucher à vos données. Actif (`true`) par défaut.
 
+## Indexation de la bibliothèque (lot 1)
+
+En parallèle, `LibraryIndexingJob` (`Worker__LibraryIndexCronExpression`, chaque dimanche 3h UTC par défaut) parcourt en **lecture seule** toute la bibliothèque Raindrop (`GET /raindrops/0`, hors corbeille) et la persiste dans `LibraryItems` — sans jamais classifier ni écrire quoi que ce soit dans Raindrop. `Worker__IndexLibraryOnStartup=true` déclenche en plus une passe au démarrage du worker, soumise à une garde : si la dernière passe complète date de moins de 24h, elle est ignorée (évite de solliciter l'API à chaque redémarrage rapproché).
+
 ## Tests automatisés
 
 ```bash

--- a/src/LoreAI.Core/Enums/ItemOrigin.cs
+++ b/src/LoreAI.Core/Enums/ItemOrigin.cs
@@ -1,0 +1,11 @@
+namespace LoreAI.Core.Enums;
+
+/// <summary>
+/// D'où provient un <see cref="Models.LibraryItem"/> au moment de l'indexation : encore dans « Non trié »
+/// (pas encore traité par <c>UnsortedClassificationJob</c>) ou déjà rangé par l'utilisateur (lot 1, #42).
+/// </summary>
+public enum ItemOrigin
+{
+    Unsorted,
+    Library,
+}

--- a/src/LoreAI.Core/Interfaces/ILibraryIndexStateRepository.cs
+++ b/src/LoreAI.Core/Interfaces/ILibraryIndexStateRepository.cs
@@ -1,0 +1,11 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Interfaces;
+
+public interface ILibraryIndexStateRepository
+{
+    Task<LibraryIndexState> GetAsync(SourceType sourceType, CancellationToken cancellationToken);
+
+    Task UpdateAsync(LibraryIndexState state, CancellationToken cancellationToken);
+}

--- a/src/LoreAI.Core/Interfaces/ILibraryItemRepository.cs
+++ b/src/LoreAI.Core/Interfaces/ILibraryItemRepository.cs
@@ -1,0 +1,9 @@
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Interfaces;
+
+public interface ILibraryItemRepository
+{
+    /// <summary>Insère ou remplace une page d'items indexés en une seule transaction — idempotent sur Item.SourceId.</summary>
+    Task UpsertPageAsync(IReadOnlyList<LibraryItem> items, DateTimeOffset indexedAtUtc, CancellationToken cancellationToken);
+}

--- a/src/LoreAI.Core/Interfaces/IRaindropClient.cs
+++ b/src/LoreAI.Core/Interfaces/IRaindropClient.cs
@@ -16,4 +16,12 @@ public interface IRaindropClient : ISourceIngester
     /// et déplacement optionnel vers une autre collection si <paramref name="collectionId"/> est fourni.
     /// </summary>
     Task UpdateRaindropAsync(long raindropId, IReadOnlyCollection<string> tags, string note, long? collectionId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Une page de toute la bibliothèque (collection 0, hors corbeille — lot 1, #42), pas les seuls nouveaux
+    /// items depuis un curseur : hors du contrat <see cref="ISourceIngester"/>, propre à ce balayage complet.
+    /// Une liste vide signale la fin — jamais déduite d'une page plus courte que demandée (même piège que
+    /// <see cref="ISourceIngester.GetNewItemsAsync"/>, voir son implémentation Raindrop).
+    /// </summary>
+    Task<IReadOnlyList<LibraryItem>> GetLibraryPageAsync(int page, CancellationToken cancellationToken);
 }

--- a/src/LoreAI.Core/Models/LibraryIndexState.cs
+++ b/src/LoreAI.Core/Models/LibraryIndexState.cs
@@ -1,0 +1,18 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Core.Models;
+
+/// <summary>
+/// Curseur de <c>LibraryIndexingJob</c> (lot 1, #42) — distinct de <see cref="PollingState"/> : ce n'est pas
+/// un dernier-item-connu mais une page de reprise dans un balayage complet de la bibliothèque, plus la date
+/// de fin de la dernière passe complète (sert de garde anti-doublon au démarrage).
+/// </summary>
+public sealed record LibraryIndexState(
+    SourceType SourceType,
+    int? ResumePage,
+    DateTimeOffset? LastFullPassStartedUtc,
+    DateTimeOffset? LastFullPassCompletedUtc,
+    DateTimeOffset UpdatedAtUtc)
+{
+    public static LibraryIndexState Initial(SourceType sourceType) => new(sourceType, null, null, null, DateTimeOffset.UnixEpoch);
+}

--- a/src/LoreAI.Core/Models/LibraryItem.cs
+++ b/src/LoreAI.Core/Models/LibraryItem.cs
@@ -1,0 +1,17 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Core.Models;
+
+/// <summary>
+/// Un item tel que vu par le balayage en lecture seule de toute la bibliothèque Raindrop (lot 1, #42) —
+/// enrichit <see cref="Item"/> des champs propres à ce balayage, jamais utilisés par le pipeline de
+/// classification (<c>UnsortedClassificationJob</c> continue de ne consommer que <see cref="Item"/>).
+/// </summary>
+public sealed record LibraryItem(
+    Item Item,
+    ItemOrigin Origin,
+    long? RaindropCollectionId,
+    bool Broken,
+    bool Important,
+    string? Cover,
+    string? HighlightsJson);

--- a/src/LoreAI.Infrastructure/Persistence/LibraryIndexStateEntity.cs
+++ b/src/LoreAI.Infrastructure/Persistence/LibraryIndexStateEntity.cs
@@ -1,0 +1,11 @@
+namespace LoreAI.Infrastructure.Persistence;
+
+/// <summary>Une ligne par source (clé <see cref="SourceType"/>) — curseur de <c>LibraryIndexingJob</c> (lot 1, #42), distinct de <see cref="PollingStateEntity"/>.</summary>
+public sealed class LibraryIndexStateEntity
+{
+    public required string SourceType { get; set; }
+    public int? ResumePage { get; set; }
+    public DateTimeOffset? LastFullPassStartedUtc { get; set; }
+    public DateTimeOffset? LastFullPassCompletedUtc { get; set; }
+    public DateTimeOffset UpdatedAtUtc { get; set; }
+}

--- a/src/LoreAI.Infrastructure/Persistence/LibraryIndexStateRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/LibraryIndexStateRepository.cs
@@ -1,0 +1,53 @@
+using Microsoft.EntityFrameworkCore;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Infrastructure.Persistence;
+
+public sealed class LibraryIndexStateRepository : ILibraryIndexStateRepository
+{
+    private readonly IDbContextFactory<LoreAiDbContext> _contextFactory;
+    private readonly PostgresSchemaGuard _schemaGuard;
+
+    public LibraryIndexStateRepository(IDbContextFactory<LoreAiDbContext> contextFactory, PostgresSchemaGuard schemaGuard)
+    {
+        _contextFactory = contextFactory;
+        _schemaGuard = schemaGuard;
+    }
+
+    public async Task<LibraryIndexState> GetAsync(SourceType sourceType, CancellationToken cancellationToken)
+    {
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var entity = await context.LibraryIndexStates.FindAsync([sourceType.ToString()], cancellationToken);
+        if (entity is null)
+        {
+            return LibraryIndexState.Initial(sourceType);
+        }
+
+        return new LibraryIndexState(sourceType, entity.ResumePage, entity.LastFullPassStartedUtc, entity.LastFullPassCompletedUtc, entity.UpdatedAtUtc);
+    }
+
+    public async Task UpdateAsync(LibraryIndexState state, CancellationToken cancellationToken)
+    {
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var key = state.SourceType.ToString();
+        var entity = await context.LibraryIndexStates.FindAsync([key], cancellationToken);
+        if (entity is null)
+        {
+            entity = new LibraryIndexStateEntity { SourceType = key };
+            context.LibraryIndexStates.Add(entity);
+        }
+
+        entity.ResumePage = state.ResumePage;
+        entity.LastFullPassStartedUtc = state.LastFullPassStartedUtc;
+        entity.LastFullPassCompletedUtc = state.LastFullPassCompletedUtc;
+        entity.UpdatedAtUtc = state.UpdatedAtUtc;
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/LoreAI.Infrastructure/Persistence/LibraryItemEntity.cs
+++ b/src/LoreAI.Infrastructure/Persistence/LibraryItemEntity.cs
@@ -1,0 +1,28 @@
+namespace LoreAI.Infrastructure.Persistence;
+
+/// <summary>
+/// Forme persistée d'un item du balayage en lecture seule de toute la bibliothèque (lot 1, #42) — table
+/// distincte d'<see cref="ArticleEntity"/> (jamais classifié, pas de write-back). Même convention de clé :
+/// <c>Id</c> reste l'id Raindrop numérique, pas de composite <c>(SourceType, SourceId)</c> tant qu'une
+/// deuxième source n'existe pas réellement (même raisonnement qu'<see cref="ArticleEntity"/>, ADR 0012).
+/// </summary>
+public sealed class LibraryItemEntity
+{
+    public long Id { get; set; }
+    public required string SourceType { get; set; }
+    public required string Title { get; set; }
+    public required string Url { get; set; }
+    public string? Excerpt { get; set; }
+    public string? Note { get; set; }
+    public string[] Tags { get; set; } = [];
+    public DateTimeOffset CapturedAtUtc { get; set; }
+
+    public required string Origin { get; set; }
+    public long? RaindropCollectionId { get; set; }
+    public bool Broken { get; set; }
+    public bool Important { get; set; }
+    public string? Cover { get; set; }
+    public string? HighlightsJson { get; set; }
+
+    public DateTimeOffset IndexedAtUtc { get; set; }
+}

--- a/src/LoreAI.Infrastructure/Persistence/LibraryItemRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/LibraryItemRepository.cs
@@ -1,0 +1,66 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Infrastructure.Persistence;
+
+public sealed class LibraryItemRepository : ILibraryItemRepository
+{
+    private readonly IDbContextFactory<LoreAiDbContext> _contextFactory;
+    private readonly PostgresSchemaGuard _schemaGuard;
+
+    public LibraryItemRepository(IDbContextFactory<LoreAiDbContext> contextFactory, PostgresSchemaGuard schemaGuard)
+    {
+        _contextFactory = contextFactory;
+        _schemaGuard = schemaGuard;
+    }
+
+    /// <summary>
+    /// Une requête <c>WHERE Id IN (...)</c> puis un seul <c>SaveChangesAsync</c> pour toute la page —
+    /// pas un aller-retour par item (cf. <c>ArticleRepository.UpsertAsync</c>) : à l'échelle de plusieurs
+    /// milliers d'items sur un Raspberry Pi (lot 1, #42), ce serait trop lent.
+    /// </summary>
+    public async Task UpsertPageAsync(IReadOnlyList<LibraryItem> items, DateTimeOffset indexedAtUtc, CancellationToken cancellationToken)
+    {
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var ids = items.Select(i => long.Parse(i.Item.SourceId, CultureInfo.InvariantCulture)).ToList();
+        var existing = await context.LibraryItems
+            .Where(e => ids.Contains(e.Id))
+            .ToDictionaryAsync(e => e.Id, cancellationToken);
+
+        foreach (var libraryItem in items)
+        {
+            var id = long.Parse(libraryItem.Item.SourceId, CultureInfo.InvariantCulture);
+            if (!existing.TryGetValue(id, out var entity))
+            {
+                entity = new LibraryItemEntity { Id = id, SourceType = string.Empty, Title = string.Empty, Url = string.Empty, Origin = string.Empty };
+                context.LibraryItems.Add(entity);
+            }
+
+            entity.SourceType = libraryItem.Item.SourceType.ToString();
+            entity.Title = libraryItem.Item.Title;
+            entity.Url = libraryItem.Item.Url;
+            entity.Excerpt = libraryItem.Item.Excerpt;
+            entity.Note = libraryItem.Item.Note;
+            entity.Tags = [.. libraryItem.Item.Tags];
+            entity.CapturedAtUtc = libraryItem.Item.CapturedAtUtc;
+            entity.Origin = libraryItem.Origin.ToString();
+            entity.RaindropCollectionId = libraryItem.RaindropCollectionId;
+            entity.Broken = libraryItem.Broken;
+            entity.Important = libraryItem.Important;
+            entity.Cover = libraryItem.Cover;
+            entity.HighlightsJson = libraryItem.HighlightsJson;
+            entity.IndexedAtUtc = indexedAtUtc;
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/LoreAI.Infrastructure/Persistence/LoreAiDbContext.cs
+++ b/src/LoreAI.Infrastructure/Persistence/LoreAiDbContext.cs
@@ -7,6 +7,8 @@ public sealed class LoreAiDbContext(DbContextOptions<LoreAiDbContext> options) :
     public DbSet<ArticleEntity> Articles => Set<ArticleEntity>();
     public DbSet<PollingStateEntity> PollingStates => Set<PollingStateEntity>();
     public DbSet<CycleRunEntity> CycleRuns => Set<CycleRunEntity>();
+    public DbSet<LibraryItemEntity> LibraryItems => Set<LibraryItemEntity>();
+    public DbSet<LibraryIndexStateEntity> LibraryIndexStates => Set<LibraryIndexStateEntity>();
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -32,6 +34,19 @@ public sealed class LoreAiDbContext(DbContextOptions<LoreAiDbContext> options) :
             // Pas de clé applicative ici (contrairement à ArticleEntity/PollingStateEntity) : Id est généré.
             cycleRun.Property(c => c.Outcome).HasConversion<string>();
             cycleRun.HasIndex(c => c.CompletedUtc);
+        });
+
+        modelBuilder.Entity<LibraryItemEntity>(libraryItem =>
+        {
+            // Même convention qu'ArticleEntity : Id est l'identifiant Raindrop, jamais généré côté base.
+            libraryItem.Property(i => i.Id).ValueGeneratedNever();
+            libraryItem.Property(i => i.HighlightsJson).HasColumnType("jsonb");
+            libraryItem.HasIndex(i => i.Origin);
+        });
+
+        modelBuilder.Entity<LibraryIndexStateEntity>(libraryIndexState =>
+        {
+            libraryIndexState.HasKey(s => s.SourceType);
         });
     }
 }

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260823151617_AddLibraryIndexing.Designer.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260823151617_AddLibraryIndexing.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LoreAI.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LoreAI.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(LoreAiDbContext))]
-    partial class LoreAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260823151617_AddLibraryIndexing")]
+    partial class AddLibraryIndexing
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260823151617_AddLibraryIndexing.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260823151617_AddLibraryIndexing.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LoreAI.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLibraryIndexing : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "LibraryIndexStates",
+                columns: table => new
+                {
+                    SourceType = table.Column<string>(type: "text", nullable: false),
+                    ResumePage = table.Column<int>(type: "integer", nullable: true),
+                    LastFullPassStartedUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    LastFullPassCompletedUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    UpdatedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LibraryIndexStates", x => x.SourceType);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "LibraryItems",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false),
+                    SourceType = table.Column<string>(type: "text", nullable: false),
+                    Title = table.Column<string>(type: "text", nullable: false),
+                    Url = table.Column<string>(type: "text", nullable: false),
+                    Excerpt = table.Column<string>(type: "text", nullable: true),
+                    Note = table.Column<string>(type: "text", nullable: true),
+                    Tags = table.Column<string[]>(type: "text[]", nullable: false),
+                    CapturedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    Origin = table.Column<string>(type: "text", nullable: false),
+                    RaindropCollectionId = table.Column<long>(type: "bigint", nullable: true),
+                    Broken = table.Column<bool>(type: "boolean", nullable: false),
+                    Important = table.Column<bool>(type: "boolean", nullable: false),
+                    Cover = table.Column<string>(type: "text", nullable: true),
+                    HighlightsJson = table.Column<string>(type: "jsonb", nullable: true),
+                    IndexedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_LibraryItems", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_LibraryItems_Origin",
+                table: "LibraryItems",
+                column: "Origin");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "LibraryIndexStates");
+
+            migrationBuilder.DropTable(
+                name: "LibraryItems");
+        }
+    }
+}

--- a/src/LoreAI.Infrastructure/Raindrop/Dto/RaindropApiDtos.cs
+++ b/src/LoreAI.Infrastructure/Raindrop/Dto/RaindropApiDtos.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace LoreAI.Infrastructure.Raindrop.Dto;
@@ -24,6 +25,13 @@ internal sealed class RaindropDto
     public string? Type { get; set; }
     public DateTimeOffset Created { get; set; }
     public DateTimeOffset? LastUpdate { get; set; }
+
+    // Ignorés jusqu'ici (n'entraient pas dans le pipeline de classification) ; utilisés par le
+    // balayage en lecture seule de toute la bibliothèque (lot 1, #42), voir MapToLibraryItem.
+    public bool Broken { get; set; }
+    public bool Important { get; set; }
+    public string? Cover { get; set; }
+    public JsonElement? Highlights { get; set; }
 }
 
 internal sealed class RaindropCollectionRefDto

--- a/src/LoreAI.Infrastructure/Raindrop/RaindropClient.cs
+++ b/src/LoreAI.Infrastructure/Raindrop/RaindropClient.cs
@@ -94,6 +94,20 @@ public sealed class RaindropClient : IRaindropClient
         return collected;
     }
 
+    public async Task<IReadOnlyList<LibraryItem>> GetLibraryPageAsync(int page, CancellationToken cancellationToken)
+    {
+        // Collection 0 = toute la bibliothèque hors corbeille (lot 1, #42) : toujours cette valeur,
+        // indépendamment de _options.CollectionId qui reste réservé à GetNewItemsAsync (-1, Non trié).
+        var url = $"raindrops/0?perpage={_options.PageSize}&page={page}";
+        var response = await _httpClient.GetAsync(url, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<RaindropsPageDto>(cancellationToken: cancellationToken)
+            ?? throw new InvalidOperationException("Réponse Raindrop vide ou invalide.");
+
+        return payload.Items.Select(MapToLibraryItem).ToList();
+    }
+
     public async Task<RaindropTaxonomy> GetTaxonomyAsync(CancellationToken cancellationToken)
     {
         var rootCollections = await GetCollectionsAsync("collections", cancellationToken);
@@ -167,4 +181,13 @@ public sealed class RaindropClient : IRaindropClient
         dto.Note,
         dto.Tags,
         dto.Created);
+
+    private static LibraryItem MapToLibraryItem(RaindropDto dto) => new(
+        MapToItem(dto),
+        dto.Collection?.Id == -1 ? ItemOrigin.Unsorted : ItemOrigin.Library,
+        dto.Collection?.Id,
+        dto.Broken,
+        dto.Important,
+        dto.Cover,
+        dto.Highlights?.GetRawText());
 }

--- a/src/LoreAI.Worker/Options/WorkerOptions.cs
+++ b/src/LoreAI.Worker/Options/WorkerOptions.cs
@@ -26,4 +26,11 @@ public sealed class WorkerOptions
     /// </summary>
     [Range(1, int.MaxValue)]
     public int HealthMaxCycleAgeMinutes { get; init; } = 45;
+
+    /// <summary>Expression cron de l'indexation en lecture seule de toute la bibliothèque (lot 1, #42) — déclenchement rare, par défaut chaque dimanche à 3h UTC.</summary>
+    [Required(AllowEmptyStrings = false)]
+    public string LibraryIndexCronExpression { get; init; } = "0 3 * * 0";
+
+    /// <summary>Inactif par défaut : lance une passe d'indexation de la bibliothèque au démarrage du worker (soumise à la garde des 24h de <c>LibraryIndexingJob</c>).</summary>
+    public bool IndexLibraryOnStartup { get; init; }
 }

--- a/src/LoreAI.Worker/Program.cs
+++ b/src/LoreAI.Worker/Program.cs
@@ -60,6 +60,8 @@ try
     builder.Services.AddSingleton<IArticleRepository, ArticleRepository>();
     builder.Services.AddSingleton<IPollingStateRepository, PollingStateRepository>();
     builder.Services.AddSingleton<ICycleRunRepository, CycleRunRepository>();
+    builder.Services.AddSingleton<ILibraryItemRepository, LibraryItemRepository>();
+    builder.Services.AddSingleton<ILibraryIndexStateRepository, LibraryIndexStateRepository>();
     // DefaultNotificationPolicy expose des seuils en paramètres de constructeur ; ils étaient annoncés
     // « injectables » mais aucun appelant ne les fournissait. On les alimente depuis la configuration ici,
     // plutôt que de faire dépendre Core de Microsoft.Extensions.Options.
@@ -85,6 +87,7 @@ try
     builder.Services.AddScheduler();
     builder.Services.AddTransient<UnsortedClassificationJob>();
     builder.Services.AddTransient<DigestNotificationJob>();
+    builder.Services.AddTransient<LibraryIndexingJob>();
 
     var host = builder.Build();
 
@@ -107,6 +110,14 @@ try
         scheduler.Schedule<DigestNotificationJob>()
             .Cron(workerOptions.DigestCronExpression)
             .PreventOverlapping(nameof(DigestNotificationJob));
+
+        var libraryIndexSchedule = scheduler.Schedule<LibraryIndexingJob>()
+            .Cron(workerOptions.LibraryIndexCronExpression)
+            .PreventOverlapping(nameof(LibraryIndexingJob));
+        if (workerOptions.IndexLibraryOnStartup)
+        {
+            libraryIndexSchedule.RunOnceAtStart();
+        }
     });
 
     host.Run();

--- a/src/LoreAI.Worker/Services/LibraryIndexingJob.cs
+++ b/src/LoreAI.Worker/Services/LibraryIndexingJob.cs
@@ -1,0 +1,118 @@
+using Coravel.Invocable;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Worker.Services;
+
+/// <summary>
+/// Indexation en lecture seule de toute la bibliothèque Raindrop (collection 0, hors corbeille — lot 1, #42) :
+/// remplit <c>LibraryItems</c> sans jamais classifier ni écrire chez Raindrop. Volontairement sans dépendance
+/// à <see cref="IClassifier"/>/<see cref="IArticleRepository"/>/<see cref="ICycleRunRepository"/> — le
+/// caractère lecture seule est garanti par la forme du constructeur, pas seulement par convention.
+/// </summary>
+public sealed class LibraryIndexingJob : IInvocable, ICancellableInvocable
+{
+    /// <summary>
+    /// Garde-fou contre une pagination qui ne se terminerait jamais (même esprit que
+    /// <c>RaindropClient.MaxPagesPerCycle</c>) — pas un découpage volontaire du travail : ce job ne fait
+    /// aucun appel LLM, une passe complète tient normalement en une seule invocation même sur un Pi. La
+    /// reprise via <c>ResumePage</c> sert à survivre à une interruption (SIGTERM, coupure), pas à étaler
+    /// une passe normale sur plusieurs cycles.
+    /// </summary>
+    private const int MaxPagesPerInvocation = 500;
+
+    /// <summary>
+    /// Évite qu'un redémarrage rapproché (déploiement, crash-loop) avec <c>Worker__IndexLibraryOnStartup=true</c>
+    /// ne relance une passe complète à chaque fois — décision produit du lot 1.
+    /// </summary>
+    private static readonly TimeSpan MinReindexInterval = TimeSpan.FromHours(24);
+
+    private readonly IRaindropClient _raindropClient;
+    private readonly ILibraryIndexStateRepository _indexStateRepository;
+    private readonly ILibraryItemRepository _libraryItemRepository;
+    private readonly ILogger<LibraryIndexingJob> _logger;
+
+    public LibraryIndexingJob(
+        IRaindropClient raindropClient,
+        ILibraryIndexStateRepository indexStateRepository,
+        ILibraryItemRepository libraryItemRepository,
+        ILogger<LibraryIndexingJob> logger)
+    {
+        _raindropClient = raindropClient;
+        _indexStateRepository = indexStateRepository;
+        _libraryItemRepository = libraryItemRepository;
+        _logger = logger;
+    }
+
+    /// <summary>Alimenté par Coravel, annulé à l'arrêt de l'application (SIGTERM, <c>docker compose down</c>).</summary>
+    public CancellationToken CancellationToken { get; set; }
+
+    public async Task Invoke()
+    {
+        var cancellationToken = CancellationToken;
+
+        var state = await _indexStateRepository.GetAsync(SourceType.Raindrop, cancellationToken);
+
+        if (state.ResumePage is null && state.LastFullPassCompletedUtc is not null
+            && DateTimeOffset.UtcNow - state.LastFullPassCompletedUtc.Value < MinReindexInterval)
+        {
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Indexation de la bibliothèque ignorée : dernière passe complète terminée le {LastCompleted}, moins de {MinInterval} auparavant.",
+                    state.LastFullPassCompletedUtc,
+                    MinReindexInterval);
+            }
+            return;
+        }
+
+        var startedUtc = state.ResumePage is null ? DateTimeOffset.UtcNow : state.LastFullPassStartedUtc ?? DateTimeOffset.UtcNow;
+        var page = state.ResumePage ?? 0;
+
+        try
+        {
+            for (var pagesFetched = 0; pagesFetched < MaxPagesPerInvocation; pagesFetched++)
+            {
+                var items = await _raindropClient.GetLibraryPageAsync(page, cancellationToken);
+
+                if (items.Count == 0)
+                {
+                    // Volontairement non annulable, comme le curseur de UnsortedClassificationJob : la
+                    // dernière page vient d'être confirmée, perdre cette écriture rejouerait toute la passe.
+                    await _indexStateRepository.UpdateAsync(
+                        new LibraryIndexState(SourceType.Raindrop, null, startedUtc, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow),
+                        CancellationToken.None);
+                    if (_logger.IsEnabled(LogLevel.Information))
+                    {
+                        _logger.LogInformation("Indexation de la bibliothèque terminée : passe complète jusqu'à la page {Page}.", page);
+                    }
+                    return;
+                }
+
+                await _libraryItemRepository.UpsertPageAsync(items, DateTimeOffset.UtcNow, cancellationToken);
+                page++;
+
+                await _indexStateRepository.UpdateAsync(
+                    new LibraryIndexState(SourceType.Raindrop, page, startedUtc, null, DateTimeOffset.UtcNow),
+                    CancellationToken.None);
+            }
+
+            _logger.LogWarning(
+                "Plafond de {MaxPages} pages atteint pour l'indexation de la bibliothèque : reprise à la page {Page} au prochain déclenchement.",
+                MaxPagesPerInvocation,
+                page);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation("Indexation de la bibliothèque interrompue par l'arrêt de l'application — reprise à la page {Page}.", page);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Échec de l'indexation de la bibliothèque — reprise à la page {Page} au prochain déclenchement.", page);
+        }
+    }
+}

--- a/tests/LoreAI.Infrastructure.Tests/Persistence/LibraryIndexStateRepositoryTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Persistence/LibraryIndexStateRepositoryTests.cs
@@ -1,0 +1,86 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Infrastructure.Persistence;
+
+namespace LoreAI.Infrastructure.Tests.Persistence;
+
+[Collection("Postgres")]
+public class LibraryIndexStateRepositoryTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fixture;
+    private readonly LibraryIndexStateRepository _repository;
+
+    public LibraryIndexStateRepositoryTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+        _repository = new LibraryIndexStateRepository(fixture.ContextFactory, new PostgresSchemaGuard(fixture.ContextFactory));
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var context = _fixture.CreateContext();
+        await context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE \"LibraryIndexStates\" RESTART IDENTITY CASCADE");
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task GetAsync_WithoutPriorState_ReturnsInitial()
+    {
+        var state = await _repository.GetAsync(SourceType.Raindrop, TestContext.Current.CancellationToken);
+
+        Assert.Equal(LibraryIndexState.Initial(SourceType.Raindrop), state);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ThenGetAsync_RoundTripsValues()
+    {
+        var expected = new LibraryIndexState(
+            SourceType.Raindrop,
+            3,
+            DateTimeOffset.Parse("2026-01-01T00:00:00Z", CultureInfo.InvariantCulture),
+            null,
+            DateTimeOffset.Parse("2026-01-02T00:00:00Z", CultureInfo.InvariantCulture));
+
+        await _repository.UpdateAsync(expected, TestContext.Current.CancellationToken);
+        var actual = await _repository.GetAsync(SourceType.Raindrop, TestContext.Current.CancellationToken);
+
+        Assert.Equal(expected.ResumePage, actual.ResumePage);
+        Assert.Equal(expected.LastFullPassStartedUtc, actual.LastFullPassStartedUtc);
+        Assert.Equal(expected.LastFullPassCompletedUtc, actual.LastFullPassCompletedUtc);
+        Assert.Equal(expected.UpdatedAtUtc, actual.UpdatedAtUtc);
+    }
+
+    /// <summary>Fin de passe : le job persiste <c>ResumePage = null</c> — vérifie que la ligne existante est bien mise à jour, pas seulement créée.</summary>
+    [Fact]
+    public async Task UpdateAsync_CompletingPass_ClearsResumePage()
+    {
+        await _repository.UpdateAsync(
+            new LibraryIndexState(SourceType.Raindrop, 5, DateTimeOffset.UtcNow, null, DateTimeOffset.UtcNow),
+            TestContext.Current.CancellationToken);
+
+        var completed = new LibraryIndexState(SourceType.Raindrop, null, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow);
+        await _repository.UpdateAsync(completed, TestContext.Current.CancellationToken);
+
+        var actual = await _repository.GetAsync(SourceType.Raindrop, TestContext.Current.CancellationToken);
+
+        Assert.Null(actual.ResumePage);
+        Assert.NotNull(actual.LastFullPassCompletedUtc);
+    }
+
+    [Fact]
+    public async Task GetAsync_DifferentSources_HaveIndependentCursors()
+    {
+        await _repository.UpdateAsync(
+            new LibraryIndexState(SourceType.Raindrop, 2, DateTimeOffset.UtcNow, null, DateTimeOffset.UtcNow),
+            TestContext.Current.CancellationToken);
+
+        var raindrop = await _repository.GetAsync(SourceType.Raindrop, TestContext.Current.CancellationToken);
+        var feed = await _repository.GetAsync(SourceType.Feed, TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, raindrop.ResumePage);
+        Assert.Equal(LibraryIndexState.Initial(SourceType.Feed), feed);
+    }
+}

--- a/tests/LoreAI.Infrastructure.Tests/Persistence/LibraryItemRepositoryTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Persistence/LibraryItemRepositoryTests.cs
@@ -1,0 +1,126 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Infrastructure.Persistence;
+
+namespace LoreAI.Infrastructure.Tests.Persistence;
+
+[Collection("Postgres")]
+public class LibraryItemRepositoryTests : IAsyncLifetime
+{
+    private readonly PostgresFixture _fixture;
+    private readonly LibraryItemRepository _repository;
+
+    public LibraryItemRepositoryTests(PostgresFixture fixture)
+    {
+        _fixture = fixture;
+        _repository = new LibraryItemRepository(fixture.ContextFactory, new PostgresSchemaGuard(fixture.ContextFactory));
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await using var context = _fixture.CreateContext();
+        await context.Database.ExecuteSqlRawAsync("TRUNCATE TABLE \"LibraryItems\" RESTART IDENTITY CASCADE");
+    }
+
+    public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+
+    [Fact]
+    public async Task UpsertPageAsync_CalledTwiceWithSameId_DoesNotDuplicate()
+    {
+        var item = CreateLibraryItem(1, "Titre initial");
+
+        await _repository.UpsertPageAsync([item], DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.UpsertPageAsync(
+            [item with { Item = item.Item with { Title = "Titre mis à jour" } }],
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken);
+
+        await using var context = _fixture.CreateContext();
+        var all = await context.LibraryItems.ToListAsync(TestContext.Current.CancellationToken);
+
+        var single = Assert.Single(all);
+        Assert.Equal("Titre mis à jour", single.Title);
+    }
+
+    [Fact]
+    public async Task UpsertPageAsync_MixedNewAndExistingIdsInSamePage_UpsertsBoth()
+    {
+        await _repository.UpsertPageAsync([CreateLibraryItem(1, "A")], DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+
+        await _repository.UpsertPageAsync(
+            [CreateLibraryItem(1, "A mis à jour"), CreateLibraryItem(2, "B")],
+            DateTimeOffset.UtcNow,
+            TestContext.Current.CancellationToken);
+
+        await using var context = _fixture.CreateContext();
+        var all = await context.LibraryItems.OrderBy(e => e.Id).ToListAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, all.Count);
+        Assert.Equal("A mis à jour", all[0].Title);
+        Assert.Equal("B", all[1].Title);
+    }
+
+    [Fact]
+    public async Task UpsertPageAsync_RoundTripsOriginAndRaindropFields()
+    {
+        var item = CreateLibraryItem(1, "A") with
+        {
+            Origin = ItemOrigin.Unsorted,
+            RaindropCollectionId = -1,
+            Broken = true,
+            Important = true,
+            Cover = "https://example.com/cover.png",
+            HighlightsJson = """[{"text":"quote"}]""",
+        };
+
+        await _repository.UpsertPageAsync([item], DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+
+        await using var context = _fixture.CreateContext();
+        var entity = await context.LibraryItems.SingleAsync(TestContext.Current.CancellationToken);
+
+        Assert.Equal("Unsorted", entity.Origin);
+        Assert.Equal(-1, entity.RaindropCollectionId);
+        Assert.True(entity.Broken);
+        Assert.True(entity.Important);
+        Assert.Equal("https://example.com/cover.png", entity.Cover);
+        Assert.NotNull(entity.HighlightsJson);
+        Assert.Contains("quote", entity.HighlightsJson);
+    }
+
+    /// <summary>Une page par appel, un seul <c>SaveChangesAsync</c> chacune — valide le pattern à l'échelle visée par le lot 1 (#42).</summary>
+    [Fact]
+    public async Task UpsertPageAsync_WithManyItemsAcrossSeveralPages_PersistsAllOfThem()
+    {
+        const int count = 500;
+        const int pageSize = 50;
+
+        for (var start = 1; start <= count; start += pageSize)
+        {
+            var page = Enumerable.Range(start, pageSize).Select(id => CreateLibraryItem(id, $"A{id}")).ToList();
+            await _repository.UpsertPageAsync(page, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        }
+
+        await using var context = _fixture.CreateContext();
+        Assert.Equal(count, await context.LibraryItems.CountAsync(TestContext.Current.CancellationToken));
+    }
+
+    [Fact]
+    public async Task UpsertPageAsync_EmptyPage_DoesNothing()
+    {
+        await _repository.UpsertPageAsync([], DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+
+        await using var context = _fixture.CreateContext();
+        Assert.Empty(await context.LibraryItems.ToListAsync(TestContext.Current.CancellationToken));
+    }
+
+    private static LibraryItem CreateLibraryItem(long id, string title) => new(
+        new Item(SourceType.Raindrop, id.ToString(CultureInfo.InvariantCulture), "https://example.com", title, "extrait", "note", [], DateTimeOffset.UtcNow),
+        ItemOrigin.Library,
+        null,
+        false,
+        false,
+        null,
+        null);
+}

--- a/tests/LoreAI.Infrastructure.Tests/Raindrop/RaindropClientTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Raindrop/RaindropClientTests.cs
@@ -183,6 +183,95 @@ public class RaindropClientTests
     }
 
     [Fact]
+    public async Task GetLibraryPageAsync_MapsBrokenImportantCoverAndHighlights()
+    {
+        using var server = WireMockServer.Start();
+        GivenPage(server, 0, """
+            { "_id": 201, "title": "Full", "link": "https://full.example", "tags": ["x"], "domain": "full.example",
+              "type": "article", "created": "2026-02-01T00:00:00Z", "collection": { "$id": 5 },
+              "broken": true, "important": true, "cover": "https://full.example/cover.png",
+              "highlights": [{ "_id": "h1", "text": "quote", "color": "yellow" }] }
+            """);
+
+        var client = CreateClient(server, pageSize: 50);
+
+        var items = await client.GetLibraryPageAsync(0, CancellationToken.None);
+
+        var single = Assert.Single(items);
+        Assert.True(single.Broken);
+        Assert.True(single.Important);
+        Assert.Equal("https://full.example/cover.png", single.Cover);
+        Assert.NotNull(single.HighlightsJson);
+        Assert.Contains("quote", single.HighlightsJson);
+        Assert.Equal(5, single.RaindropCollectionId);
+        Assert.Equal(ItemOrigin.Library, single.Origin);
+    }
+
+    [Fact]
+    public async Task GetLibraryPageAsync_NoHighlightsField_HighlightsJsonIsNull()
+    {
+        using var server = WireMockServer.Start();
+        GivenPage(server, 0, ItemJson(101, "2026-01-01T00:00:00Z"));
+
+        var client = CreateClient(server, pageSize: 50);
+
+        var items = await client.GetLibraryPageAsync(0, CancellationToken.None);
+
+        Assert.Null(Assert.Single(items).HighlightsJson);
+    }
+
+    [Fact]
+    public async Task GetLibraryPageAsync_CollectionIdIsMinusOne_OriginIsUnsorted()
+    {
+        using var server = WireMockServer.Start();
+        GivenPage(server, 0, """
+            { "_id": 301, "title": "Non trié", "link": "https://x.example", "tags": [], "domain": "x.example",
+              "type": "article", "created": "2026-01-01T00:00:00Z", "collection": { "$id": -1 } }
+            """);
+
+        var client = CreateClient(server, pageSize: 50);
+
+        var items = await client.GetLibraryPageAsync(0, CancellationToken.None);
+
+        Assert.Equal(ItemOrigin.Unsorted, Assert.Single(items).Origin);
+    }
+
+    [Fact]
+    public async Task GetLibraryPageAsync_EmptyPage_ReturnsEmpty()
+    {
+        using var server = WireMockServer.Start();
+        GivenPage(server, 0, string.Empty);
+
+        var client = CreateClient(server, pageSize: 50);
+
+        Assert.Empty(await client.GetLibraryPageAsync(0, CancellationToken.None));
+    }
+
+    /// <summary>Toute la bibliothèque, indépendamment de la collection configurée pour GetNewItemsAsync (lot 1, #42).</summary>
+    [Fact]
+    public async Task GetLibraryPageAsync_IgnoresConfiguredCollectionId_AlwaysTargetsCollectionZero()
+    {
+        using var server = WireMockServer.Start();
+        GivenPage(server, 0, string.Empty);
+
+        var httpClient = new HttpClient();
+        var options = Options.Create(new RaindropApiOptions
+        {
+            BaseUrl = $"{server.Urls[0]}/rest/v1",
+            Token = "test-token",
+            CollectionId = -1,
+            PageSize = 50,
+        });
+        var client = new RaindropClient(httpClient, options, NullLogger<RaindropClient>.Instance);
+
+        await client.GetLibraryPageAsync(0, CancellationToken.None);
+
+        var logEntry = Assert.Single(server.LogEntries);
+        Assert.NotNull(logEntry.RequestMessage);
+        Assert.Equal("/rest/v1/raindrops/0", logEntry.RequestMessage.Path);
+    }
+
+    [Fact]
     public async Task UpdateRaindropAsync_WithoutCollectionId_DoesNotIncludeCollectionInBody()
     {
         using var server = WireMockServer.Start();

--- a/tests/LoreAI.Worker.Tests/Services/LibraryIndexingJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/LibraryIndexingJobTests.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+using LoreAI.Worker.Services;
+
+namespace LoreAI.Worker.Tests.Services;
+
+/// <summary>Couvre l'orchestration de l'indexation en lecture seule de la bibliothèque (lot 1, #42) : reprise sur interruption, garde anti-doublon, plafond défensif.</summary>
+public class LibraryIndexingJobTests
+{
+    [Fact]
+    public void Constructor_HasNoDependencyOnClassificationOrWriteBackTypes()
+    {
+        // Le caractère lecture seule est garanti par la forme du constructeur, pas seulement par
+        // convention : aucun de ces types ne doit pouvoir y entrer, même par erreur future.
+        var parameterTypes = typeof(LibraryIndexingJob)
+            .GetConstructors().Single().GetParameters().Select(p => p.ParameterType).ToList();
+
+        Assert.DoesNotContain(typeof(IClassifier), parameterTypes);
+        Assert.DoesNotContain(typeof(IArticleRepository), parameterTypes);
+        Assert.DoesNotContain(typeof(ICycleRunRepository), parameterTypes);
+    }
+
+    [Fact]
+    public async Task Invoke_FreshStart_PagesUntilEmptyThenMarksPassComplete()
+    {
+        var fixture = new JobFixture();
+        fixture.RaindropClient.GetLibraryPageAsync(0, Arg.Any<CancellationToken>()).Returns([CreateLibraryItem(1)]);
+        fixture.RaindropClient.GetLibraryPageAsync(1, Arg.Any<CancellationToken>()).Returns(Array.Empty<LibraryItem>());
+
+        await fixture.Build().Invoke();
+
+        await fixture.LibraryItemRepository.Received(1).UpsertPageAsync(
+            Arg.Is<IReadOnlyList<LibraryItem>>(items => items!.Count == 1), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await fixture.IndexStateRepository.Received(1).UpdateAsync(
+            Arg.Is<LibraryIndexState>(s => s!.ResumePage == null && s.LastFullPassCompletedUtc != null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_ResumesFromPersistedPage()
+    {
+        var fixture = new JobFixture()
+            .WithState(new LibraryIndexState(SourceType.Raindrop, 3, DateTimeOffset.UtcNow.AddMinutes(-5), null, DateTimeOffset.UtcNow));
+        fixture.RaindropClient.GetLibraryPageAsync(3, Arg.Any<CancellationToken>()).Returns(Array.Empty<LibraryItem>());
+
+        await fixture.Build().Invoke();
+
+        await fixture.RaindropClient.Received(1).GetLibraryPageAsync(3, Arg.Any<CancellationToken>());
+        await fixture.RaindropClient.DidNotReceive().GetLibraryPageAsync(0, Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Garde défensive contre une pagination sans fin — voir la constante dans <see cref="LibraryIndexingJob"/>.</summary>
+    [Fact]
+    public async Task Invoke_HitsMaxPagesPerInvocation_PersistsResumePageAndStopsWithoutError()
+    {
+        const int maxPagesPerInvocation = 500;
+        var fixture = new JobFixture();
+        fixture.RaindropClient.GetLibraryPageAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([CreateLibraryItem(1)]);
+
+        var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());
+
+        Assert.Null(exception);
+        await fixture.RaindropClient.Received(maxPagesPerInvocation).GetLibraryPageAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await fixture.IndexStateRepository.Received(1).UpdateAsync(
+            Arg.Is<LibraryIndexState>(s => s!.ResumePage == maxPagesPerInvocation), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_TransientException_LeavesStateAtLastSuccessfullyPersistedPage()
+    {
+        var fixture = new JobFixture();
+        fixture.RaindropClient.GetLibraryPageAsync(0, Arg.Any<CancellationToken>()).Returns([CreateLibraryItem(1)]);
+        fixture.RaindropClient.GetLibraryPageAsync(1, Arg.Any<CancellationToken>()).Returns([CreateLibraryItem(2)]);
+        fixture.RaindropClient.GetLibraryPageAsync(2, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("502", null, HttpStatusCode.BadGateway));
+
+        var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());
+
+        Assert.Null(exception);
+        await fixture.LibraryItemRepository.Received(2).UpsertPageAsync(
+            Arg.Any<IReadOnlyList<LibraryItem>>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await fixture.IndexStateRepository.Received(1).UpdateAsync(
+            Arg.Is<LibraryIndexState>(s => s!.ResumePage == 2), Arg.Any<CancellationToken>());
+    }
+
+    // --- Garde anti-doublon (24h) ---------------------------------------------------------------
+
+    [Fact]
+    public async Task Invoke_LastFullPassCompletedRecently_SkipsWithoutCallingApi()
+    {
+        var fixture = new JobFixture()
+            .WithState(new LibraryIndexState(SourceType.Raindrop, null, DateTimeOffset.UtcNow.AddHours(-2), DateTimeOffset.UtcNow.AddHours(-1), DateTimeOffset.UtcNow));
+
+        await fixture.Build().Invoke();
+
+        await fixture.RaindropClient.DidNotReceive().GetLibraryPageAsync(Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await fixture.IndexStateRepository.DidNotReceive().UpdateAsync(Arg.Any<LibraryIndexState>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_LastFullPassCompletedOverADayAgo_StartsNewPass()
+    {
+        var fixture = new JobFixture()
+            .WithState(new LibraryIndexState(SourceType.Raindrop, null, DateTimeOffset.UtcNow.AddHours(-26), DateTimeOffset.UtcNow.AddHours(-25), DateTimeOffset.UtcNow));
+        fixture.RaindropClient.GetLibraryPageAsync(0, Arg.Any<CancellationToken>()).Returns(Array.Empty<LibraryItem>());
+
+        await fixture.Build().Invoke();
+
+        await fixture.RaindropClient.Received(1).GetLibraryPageAsync(0, Arg.Any<CancellationToken>());
+    }
+
+    private static LibraryItem CreateLibraryItem(long id) => new(
+        new Item(SourceType.Raindrop, id.ToString(CultureInfo.InvariantCulture), $"https://example.com/{id}", $"Article {id}", null, null, [], DateTimeOffset.UnixEpoch),
+        ItemOrigin.Library,
+        null,
+        false,
+        false,
+        null,
+        null);
+
+    private sealed class JobFixture
+    {
+        public IRaindropClient RaindropClient { get; } = Substitute.For<IRaindropClient>();
+        public ILibraryIndexStateRepository IndexStateRepository { get; } = Substitute.For<ILibraryIndexStateRepository>();
+        public ILibraryItemRepository LibraryItemRepository { get; } = Substitute.For<ILibraryItemRepository>();
+
+        public JobFixture()
+        {
+            IndexStateRepository.GetAsync(Arg.Any<SourceType>(), Arg.Any<CancellationToken>())
+                .Returns(LibraryIndexState.Initial(SourceType.Raindrop));
+            RaindropClient.GetLibraryPageAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
+                .Returns(Array.Empty<LibraryItem>());
+        }
+
+        public JobFixture WithState(LibraryIndexState state)
+        {
+            IndexStateRepository.GetAsync(Arg.Any<SourceType>(), Arg.Any<CancellationToken>()).Returns(state);
+            return this;
+        }
+
+        public LibraryIndexingJob Build() => new(RaindropClient, IndexStateRepository, LibraryItemRepository, NullLogger<LibraryIndexingJob>.Instance);
+    }
+}


### PR DESCRIPTION
## Résumé

- `LibraryIndexingJob` (Coravel, `Worker__LibraryIndexCronExpression`, hebdomadaire par défaut + `Worker__IndexLibraryOnStartup` en option) parcourt `GET /raindrops/0` en **lecture seule** : jamais de classification, jamais d'écriture chez Raindrop.
- Persiste dans deux tables neuves et purement additives : `LibraryItems` (discriminant `SourceType` + `Origin` `Unsorted`/`Library`, champs jusqu'ici ignorés `broken`/`important`/`cover`/`highlights`) et `LibraryIndexStates` (curseur de page reprenable, indépendant du curseur de `UnsortedClassificationJob`).
- `Articles`/`PollingStates`/`CycleRuns` restent strictement inchangées — voir la note ADR 0012 ci-dessous.
- Garde anti-doublon : au démarrage, ignore une nouvelle passe si la précédente s'est terminée il y a moins de 24h (protège l'API Raindrop des redémarrages rapprochés).
- Plafond défensif de 500 pages par invocation (même esprit que `RaindropClient.MaxPagesPerCycle`), pas un mécanisme de découpage — ce job ne fait aucun appel LLM.

## Pourquoi pas étendre `Articles` ?

[ADR 0012](docs/adr/0012-modele-item-generique-multi-sources.md) — écrite explicitement en vue de ce lot — a déjà tranché qu'`Articles` reste mono-source (pas de colonnes `SourceType`/origine) tant qu'une deuxième source n'existe pas *réellement*. Le lot 1 reste Raindrop (juste une autre collection) : rouvrir `Articles` contredirait cette décision. D'où deux tables neuves plutôt qu'une extension.

## Test plan

- [x] `dotnet build LoreAI.slnx` — 0 erreur
- [x] Migration générée (`AddLibraryIndexing`) relue : strictement deux `CreateTable`, zéro ligne touchant `Articles`/`PollingStates`/`CycleRuns`
- [x] `dotnet test LoreAI.slnx` — 153/153 verts (WireMock pour `GetLibraryPageAsync`, Testcontainers.PostgreSql pour les deux nouveaux repositories, NSubstitute pur pour `LibraryIndexingJob` — reprise, garde 24h, plafond, isolation d'erreur)
- [x] Test manuel contre un vrai compte Raindrop (`Worker__IndexLibraryOnStartup=true`) — validé en prod sur `mcm8` : passe complète en 27 pages, puis cycle de classification enchaîné normalement

Closes #42.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
