### PR TITLE
feat: compte-rendu de cycle Discord (O1, #31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LoreAI
 
-Outil .NET 10 qui trie automatiquement le backlog de la collection **« Non trié »** de Raindrop.io. Il apprend vos collections et tags réels (via l'API Raindrop), classifie chaque nouvel article avec Claude Haiku en s'appuyant sur cette taxonomie, puis applique directement le résultat : tags fusionnés et déplacement vers la collection identifiée si elle correspond — sans étape de validation manuelle. Une notification Discord signale en plus les articles jugés prioritaires à tester, et un digest email quotidien récapitule tout le reste.
+Outil .NET 10 qui trie automatiquement le backlog de la collection **« Non trié »** de Raindrop.io. Il apprend vos collections et tags réels (via l'API Raindrop), classifie chaque nouvel article avec Claude Haiku en s'appuyant sur cette taxonomie, puis applique directement le résultat : tags fusionnés et déplacement vers la collection identifiée si elle correspond — sans étape de validation manuelle. Une notification Discord signale en plus les articles jugés prioritaires à tester, un compte-rendu Discord clôture chaque cycle ayant traité au moins un article, et un digest email quotidien récapitule tout le reste.
 
 Tout ce qui se trouve **en dehors** de « Non trié » est considéré comme déjà classé par vos soins et n'est jamais retouché.
 
@@ -126,6 +126,6 @@ Aucune vraie clé nécessaire : les appels Raindrop/Anthropic/Discord sont simul
 5. Ajouter un raindrop test dans « Non trié » via l'app Raindrop pendant que le worker tourne, attendre le prochain cycle.
 6. Inspecter la table `Articles` sur l'instance PostgreSQL (`psql` ou un client graphique) — vérifier les colonnes `SuggestedCollection`/`SuggestedTags`/`RecommendedAction`/`Priority`/`Reason`.
 7. Repasser `WriteBackToRaindrop` à `true` pour valider l'application réelle (tags + déplacement) sur un raindrop de test, puis vérifier dans l'app Raindrop que le résultat correspond à la ligne en base.
-8. Vérifier la réception Discord (si le raindrop test matche le seuil ATester/Haute) et le digest email (regroupement par collection puis action).
+8. Vérifier la réception Discord : l'alerte immédiate (si le raindrop test matche le seuil ATester/Haute), le compte-rendu de fin de cycle (traités/déplacés/tags), et le digest email (regroupement par collection puis action).
 
 ⚠️ Ce test réel consomme de vrais appels à l'API Anthropic (coût minime mais réel) et modifie votre vrai compte Raindrop dès que `WriteBackToRaindrop=true`.

--- a/src/LoreAI.Core/Interfaces/ICycleReportNotifier.cs
+++ b/src/LoreAI.Core/Interfaces/ICycleReportNotifier.cs
@@ -1,0 +1,13 @@
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Interfaces;
+
+/// <summary>
+/// Compte-rendu de fin de cycle (issue #31) : au plus une notification par exécution de
+/// <c>UnsortedClassificationJob</c>, uniquement quand au moins un article était à traiter — jamais sur un
+/// cycle vide ni sur un échec avant même de savoir s'il y avait quelque chose (voir <see cref="CycleOutcome"/>).
+/// </summary>
+public interface ICycleReportNotifier
+{
+    Task NotifyCycleCompletedAsync(CycleRun run, CancellationToken cancellationToken);
+}

--- a/src/LoreAI.Infrastructure/Notifications/DiscordCycleReportNotifier.cs
+++ b/src/LoreAI.Infrastructure/Notifications/DiscordCycleReportNotifier.cs
@@ -1,0 +1,57 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Infrastructure.Notifications;
+
+/// <summary>
+/// Compte-rendu de fin de cycle (issue #31), un envoi par cycle ayant traité au moins un article.
+/// N'échoue jamais bruyamment : une panne Discord ne doit pas faire échouer le cycle qu'elle rapporte.
+/// </summary>
+public sealed class DiscordCycleReportNotifier : ICycleReportNotifier
+{
+    private readonly HttpClient _httpClient;
+    private readonly DiscordOptions _options;
+    private readonly ILogger<DiscordCycleReportNotifier> _logger;
+
+    public DiscordCycleReportNotifier(HttpClient httpClient, IOptions<DiscordOptions> options, ILogger<DiscordCycleReportNotifier> logger)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task NotifyCycleCompletedAsync(CycleRun run, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var payload = new { content = FormatMessage(run) };
+            var response = await _httpClient.PostAsJsonAsync(_options.WebhookUrl, payload, cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Échec de l'envoi du compte-rendu de cycle sur Discord.");
+        }
+    }
+
+    private static string FormatMessage(CycleRun run)
+    {
+        var stayed = run.ItemsProcessed - run.Moved;
+        var header = run.Outcome == CycleOutcome.Interrupted
+            ? $"**Cycle interrompu — {run.ItemsProcessed.ToString(CultureInfo.InvariantCulture)}/{run.ItemsSeen.ToString(CultureInfo.InvariantCulture)} articles traités**"
+            : $"**Cycle terminé — {run.ItemsProcessed.ToString(CultureInfo.InvariantCulture)}/{run.ItemsSeen.ToString(CultureInfo.InvariantCulture)} articles traités**";
+
+        var body = $"Déplacés : {run.Moved.ToString(CultureInfo.InvariantCulture)} — " +
+                   $"Restés dans « Non trié » : {stayed.ToString(CultureInfo.InvariantCulture)} — " +
+                   $"Tags ajoutés : {run.TagsApplied.ToString(CultureInfo.InvariantCulture)}";
+
+        return run.FailureReason is null
+            ? $"{header}\n{body}"
+            : $"{header}\n{body}\n⚠️ {run.FailureReason}";
+    }
+}

--- a/src/LoreAI.Worker/Program.cs
+++ b/src/LoreAI.Worker/Program.cs
@@ -84,6 +84,9 @@ try
     builder.Services.AddHttpClient<IImmediateNotifier, DiscordNotifier>()
         .AddStandardResilienceHandler();
 
+    builder.Services.AddHttpClient<ICycleReportNotifier, DiscordCycleReportNotifier>()
+        .AddStandardResilienceHandler();
+
     builder.Services.AddScheduler();
     builder.Services.AddTransient<UnsortedClassificationJob>();
     builder.Services.AddTransient<DigestNotificationJob>();

--- a/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
+++ b/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
@@ -21,6 +21,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
     private readonly IPollingStateRepository _pollingStateRepository;
     private readonly IArticleRepository _articleRepository;
     private readonly ICycleRunRepository _cycleRunRepository;
+    private readonly ICycleReportNotifier _cycleReportNotifier;
     private readonly IClassifier _classifier;
     private readonly IImmediateNotifier _immediateNotifier;
     private readonly INotificationPolicy _notificationPolicy;
@@ -32,6 +33,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
         IPollingStateRepository pollingStateRepository,
         IArticleRepository articleRepository,
         ICycleRunRepository cycleRunRepository,
+        ICycleReportNotifier cycleReportNotifier,
         IClassifier classifier,
         IImmediateNotifier immediateNotifier,
         INotificationPolicy notificationPolicy,
@@ -42,6 +44,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
         _pollingStateRepository = pollingStateRepository;
         _articleRepository = articleRepository;
         _cycleRunRepository = cycleRunRepository;
+        _cycleReportNotifier = cycleReportNotifier;
         _classifier = classifier;
         _immediateNotifier = immediateNotifier;
         _notificationPolicy = notificationPolicy;
@@ -220,6 +223,20 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "Échec de l'enregistrement du journal de cycle.");
+            }
+
+            // Pas d'import, pas de notification (#31) : un cycle vide, ou un échec avant même de savoir
+            // s'il y avait quelque chose à traiter (itemsSeen == 0 dans les deux cas), reste silencieux.
+            if (run.ItemsSeen > 0)
+            {
+                try
+                {
+                    await _cycleReportNotifier.NotifyCycleCompletedAsync(run, CancellationToken.None);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "Échec de l'envoi du compte-rendu de cycle.");
+                }
             }
         }
     }

--- a/tests/LoreAI.Infrastructure.Tests/Notifications/DiscordCycleReportNotifierTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Notifications/DiscordCycleReportNotifierTests.cs
@@ -1,0 +1,107 @@
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Infrastructure.Notifications;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace LoreAI.Infrastructure.Tests.Notifications;
+
+public class DiscordCycleReportNotifierTests
+{
+    [Fact]
+    public async Task NotifyCycleCompletedAsync_PostsMessageContainingCounts()
+    {
+        using var server = WireMockServer.Start();
+        server
+            .Given(Request.Create().WithPath("/webhook").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var notifier = CreateNotifier(server);
+        var run = new CycleRun(
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch.AddMinutes(1),
+            CycleOutcome.Ok,
+            ItemsSeen: 5,
+            ItemsProcessed: 5,
+            Moved: 3,
+            TagsApplied: 7,
+            Notified: 1,
+            FailureReason: null);
+
+        await notifier.NotifyCycleCompletedAsync(run, CancellationToken.None);
+
+        var logEntry = Assert.Single(server.LogEntries);
+        Assert.NotNull(logEntry.RequestMessage);
+        var content = JsonDocument.Parse(logEntry.RequestMessage.Body!).RootElement.GetProperty("content").GetString();
+        Assert.Contains("5/5", content);
+        Assert.Contains("Déplacés : 3", content);
+        // 5 traités - 3 déplacés = 2 restés dans « Non trié ».
+        Assert.Contains("Restés dans « Non trié » : 2", content);
+        Assert.Contains("Tags ajoutés : 7", content);
+    }
+
+    [Fact]
+    public async Task NotifyCycleCompletedAsync_InterruptedRun_IncludesFailureReason()
+    {
+        using var server = WireMockServer.Start();
+        server
+            .Given(Request.Create().WithPath("/webhook").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var notifier = CreateNotifier(server);
+        var run = new CycleRun(
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch.AddMinutes(1),
+            CycleOutcome.Interrupted,
+            ItemsSeen: 3,
+            ItemsProcessed: 1,
+            Moved: 0,
+            TagsApplied: 2,
+            Notified: 0,
+            FailureReason: "Classification en repli pour l'item 42.");
+
+        await notifier.NotifyCycleCompletedAsync(run, CancellationToken.None);
+
+        var logEntry = Assert.Single(server.LogEntries);
+        Assert.NotNull(logEntry.RequestMessage);
+        var content = JsonDocument.Parse(logEntry.RequestMessage.Body!).RootElement.GetProperty("content").GetString();
+        Assert.Contains("interrompu", content, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Classification en repli pour l'item 42.", content);
+    }
+
+    [Fact]
+    public async Task NotifyCycleCompletedAsync_HttpFailure_DoesNotThrow()
+    {
+        using var server = WireMockServer.Start();
+        server
+            .Given(Request.Create().WithPath("/webhook").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        var notifier = CreateNotifier(server);
+        var run = new CycleRun(
+            DateTimeOffset.UnixEpoch,
+            DateTimeOffset.UnixEpoch.AddMinutes(1),
+            CycleOutcome.Ok,
+            ItemsSeen: 1,
+            ItemsProcessed: 1,
+            Moved: 0,
+            TagsApplied: 0,
+            Notified: 0,
+            FailureReason: null);
+
+        var exception = await Record.ExceptionAsync(() => notifier.NotifyCycleCompletedAsync(run, CancellationToken.None));
+
+        Assert.Null(exception);
+    }
+
+    private static DiscordCycleReportNotifier CreateNotifier(WireMockServer server)
+    {
+        var httpClient = new HttpClient();
+        var options = Options.Create(new DiscordOptions { WebhookUrl = $"{server.Urls[0]}/webhook" });
+        return new DiscordCycleReportNotifier(httpClient, options, NullLogger<DiscordCycleReportNotifier>.Instance);
+    }
+}

--- a/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
@@ -468,6 +468,76 @@ public class UnsortedClassificationJobTests
         Assert.Null(exception);
     }
 
+    // --- Compte-rendu de cycle sur Discord (#31) ------------------------------------------------
+
+    [Fact]
+    public async Task Invoke_NoNewItems_DoesNotSendCycleReport()
+    {
+        var fixture = new JobFixture().WithNewItems();
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleReportNotifier.DidNotReceive().NotifyCycleCompletedAsync(
+            Arg.Any<CycleRun>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_RaindropUnavailable_DoesNotSendCycleReport()
+    {
+        var fixture = new JobFixture();
+        fixture.RaindropClient
+            .GetNewItemsAsync(Arg.Any<PollingState>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("401 Unauthorized"));
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleReportNotifier.DidNotReceive().NotifyCycleCompletedAsync(
+            Arg.Any<CycleRun>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_AllItemsProcessed_SendsCycleReport()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1))
+            .WithClassification(CreateClassification(".NET", ["dotnet"]));
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleReportNotifier.Received(1).NotifyCycleCompletedAsync(
+            Arg.Is<CycleRun>(r => r!.Outcome == CycleOutcome.Ok), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_FallbackClassification_StillSendsCycleReportWithReason()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1), CreateItem(2))
+            .WithClassification(ClassificationResult.Fallback("model", "Classification échouée: 429", "{}"));
+
+        await fixture.Build().Invoke();
+
+        await fixture.CycleReportNotifier.Received(1).NotifyCycleCompletedAsync(
+            Arg.Is<CycleRun>(r => r!.Outcome == CycleOutcome.Interrupted && r.FailureReason != null),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Un échec d'envoi du compte-rendu est un détail d'observabilité : jamais fatal au cycle.</summary>
+    [Fact]
+    public async Task Invoke_CycleReportNotifierFails_DoesNotThrow()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem(1))
+            .WithClassification(CreateClassification(".NET", ["dotnet"]));
+        fixture.CycleReportNotifier
+            .NotifyCycleCompletedAsync(Arg.Any<CycleRun>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("500"));
+
+        var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());
+
+        Assert.Null(exception);
+    }
+
     // --- Fixture ------------------------------------------------------------------------------
 
     private static Item CreateItem(long id, IReadOnlyList<string>? tags = null) => new(
@@ -492,6 +562,7 @@ public class UnsortedClassificationJobTests
         public IPollingStateRepository PollingStateRepository { get; } = Substitute.For<IPollingStateRepository>();
         public IArticleRepository ArticleRepository { get; } = Substitute.For<IArticleRepository>();
         public ICycleRunRepository CycleRunRepository { get; } = Substitute.For<ICycleRunRepository>();
+        public ICycleReportNotifier CycleReportNotifier { get; } = Substitute.For<ICycleReportNotifier>();
         public IClassifier Classifier { get; } = Substitute.For<IClassifier>();
         public IImmediateNotifier ImmediateNotifier { get; } = Substitute.For<IImmediateNotifier>();
         public INotificationPolicy NotificationPolicy { get; } = Substitute.For<INotificationPolicy>();
@@ -544,6 +615,7 @@ public class UnsortedClassificationJobTests
             PollingStateRepository,
             ArticleRepository,
             CycleRunRepository,
+            CycleReportNotifier,
             Classifier,
             ImmediateNotifier,
             NotificationPolicy,


### PR DESCRIPTION
## Summary
- Ajoute `ICycleReportNotifier` (Core) / `DiscordCycleReportNotifier` (Infrastructure) : une notification Discord de fin de cycle, réutilisant `Discord__WebhookUrl` existant.
- `UnsortedClassificationJob` l'appelle en fin de cycle uniquement si au moins un article a été vu (`ItemsSeen > 0`) — jamais sur cycle vide ni sur échec avant de savoir s'il y avait quelque chose, conformément à la règle « pas d'import, pas de notification » de #31.
- Contenu : articles vus/traités, déplacés vs restés dans « Non trié », tags **réellement** ajoutés (fusion insensible à la casse déjà correcte), et la raison en cas d'interruption.
- Prérequis explicite (issue #43, lot 2) avant la suppression du digest email.

## Test plan
- [x] `dotnet test LoreAI.slnx` — 161/161 verts (Docker requis pour Testcontainers.PostgreSql)
- [x] Nouveaux tests `UnsortedClassificationJobTests` couvrant les 4 lignes de la table de déclenchement (#31)
- [x] Nouveaux tests `DiscordCycleReportNotifierTests` (format du message, échec HTTP non bloquant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD9QVSMUUkykAme7rp9Bqa