### PR TITLE
feat: boucle de retour (lot 6, #47)

### DIFF
--- a/docs/etat-des-lieux.md
+++ b/docs/etat-des-lieux.md
@@ -4,7 +4,7 @@
 > L'historique est dans `git log` et les Releases. La cible est dans [`roadmap.md`](roadmap.md). Les décisions sont dans [`adr/`](adr/).
 > Le suivi des lots est dans les [issues #41 à #51](https://github.com/slucky31/LoreAI/issues?q=is%3Aissue+milestone%3A*).
 
-**Dernière mise à jour :** 2026-08-24 · **Version publiée :** 0.14.0
+**Dernière mise à jour :** 2026-08-25 · **Version publiée :** 0.14.0
 
 ---
 
@@ -12,10 +12,10 @@
 
 | | |
 |---|---|
-| **Lot en cours** | **Lot 5 ([#46](https://github.com/slucky31/LoreAI/issues/46)) mergé, déployé et vérifié en production sur `mcm8` aux 4/5** (PR [#69](https://github.com/slucky31/LoreAI/pull/69) → release v0.14.0). Vérifié le 2026-08-24 via le MCP en conditions réelles (1333 items indexés) : `search_items` (Q2, plein texte réel, résultats pertinents), `find_similar` (S5, exclut bien la source), `export_item` (S8, frontmatter correct, gère bien le cas « jamais classifié »). **`catalog_tools`/`tool_card` (S7) confirmés** : un cycle réel a classé l'article « browser-use » en `ATester`, la table `Tools` s'est peuplée automatiquement, `tool_card` rend une fiche Markdown correcte (frontmatter + article lié + résumé). **Seul reste à vérifier** : `MonthlyReviewJob` (S4) — cron 1er du mois 5h UTC, pas de `RunOnceAtStart()` : premier passage réel le **2026-09-01**, chercher `loreai-revue-mensuelle-2026-08.md` sur Discord. |
-| **Prochain geste** | Repasser vérifier `MonthlyReviewJob` le 2026-09-01 — dernier morceau du lot 5. Indépendamment : lot 2 ([#43](https://github.com/slucky31/LoreAI/issues/43)) vérifié aux 2/3 — seul `WeeklyInsightsJob` (N1/N2/N5/S3/S6) reste à vérifier en prod, cron dimanche 3h/4h UTC : **on attend le prochain passage naturel, dimanche 2026-08-30**. Chercher dans Discord un fichier attaché `loreai-insights-2026-08-30.md`. |
+| **Lot en cours** | **Lot 6 ([#47](https://github.com/slucky31/LoreAI/issues/47)) implémenté sur `feat/lot6-boucle-de-retour`, pas encore poussé/PR.** 5 commits : L3 (`ReconciliationJob`, nouveau job quotidien qui détecte tags/collection modifiés par l'utilisateur, articles supprimés/liens cassés) + L4 (relance Discord greffée dans le même job) ; N3/N4/L1 (liens morts suivis, péremption, file de lecture scorée — intégrés au rapport hebdomadaire + outil MCP `reading_queue`, qui remplace son stub « non implémenté ») ; O4 (`TZ=Europe/Paris` sur les deux Dockerfiles, non vérifié par un build Docker réel) ; O5 (`--run-weekly-insights`/`--run-monthly-review`) ; S9 (`toolUrl` de bout en bout). **L5 volontairement exclu** (écriture hors « Non trié », validation explicite requise avant). Deux migrations EF Core (`AddReconciliationFields`, `AddToolUrl`). 318/318 tests passent, y compris `Infrastructure.Tests` (Testcontainers/Postgres, vérifié avec Docker actif). Lot 5 ([#46](https://github.com/slucky31/LoreAI/issues/46)) reste mergé/déployé/vérifié à 5/6 — seul `MonthlyReviewJob` (S4) attend son premier passage réel le 2026-09-01. |
+| **Prochain geste** | Pousser `feat/lot6-boucle-de-retour` et ouvrir la PR lot 6. Une fois mergé/déployé : vérifier en prod `ReconciliationJob` (cron quotidien 2h UTC) et la relance L4, puis le prochain rapport hebdomadaire pour les nouvelles sections N3/N4/L1. Indépendamment : repasser vérifier `MonthlyReviewJob` le 2026-09-01 (dernier morceau du lot 5), et `WeeklyInsightsJob` du lot 2 reste à vérifier en prod côté N1/N2/N5/S3/S6 — cron dimanche 3h/4h UTC, prochain passage naturel 2026-08-30 (chercher `loreai-insights-2026-08-30.md` sur Discord). |
 | **Dernière décision** | **#34 (cache de prompt) tranché par une mesure réelle, 2026-08-24 : sans effet, comme prévu.** 5 échantillons post-déploiement du lot 4 (`cache_control` posé sur le tool `classify`) : `cache_creation_input_tokens`/`cache_read_input_tokens` à 0 partout — le préfixe cacheable (system + tools, ~900 tokens estimés) reste bien sous le seuil de 4096 tokens de Claude Haiku 4.5. Sujet clos jusqu'à un vrai backfill (seul scénario où le cache change la facture, cf. roadmap) ; le marqueur reste en place, sans effet ni coût tant que le seuil n'est pas atteint. |
-| **Bloqué par** | Rien. Le Pi (`mcm8`) est en ligne, le lot 4 est vérifié en production. |
+| **Bloqué par** | Rien. Le Pi (`mcm8`) est en ligne. |
 
 ## Ce qui tourne aujourd'hui
 

--- a/src/LoreAI.Core/Enums/LinkStatus.cs
+++ b/src/LoreAI.Core/Enums/LinkStatus.cs
@@ -1,0 +1,15 @@
+namespace LoreAI.Core.Enums;
+
+/// <summary>
+/// État d'un lien tel que constaté à la dernière passe de <c>ReconciliationJob</c> (L3, lot 6).
+/// <c>null</c> côté <see cref="LoreAI.Core.Models.TrackedArticle"/>/<c>ArticleEntity</c> signifie
+/// « jamais réconcilié », distinct d'<see cref="Ok"/> qui est une constatation positive.
+/// </summary>
+public enum LinkStatus
+{
+    Ok,
+    Broken,
+
+    /// <summary>L'item n'existe plus côté Raindrop (404) — supprimé définitivement, pas seulement mis à la corbeille.</summary>
+    Deleted,
+}

--- a/src/LoreAI.Core/Interfaces/IArticleRepository.cs
+++ b/src/LoreAI.Core/Interfaces/IArticleRepository.cs
@@ -1,3 +1,4 @@
+using LoreAI.Core.Enums;
 using LoreAI.Core.Models;
 
 namespace LoreAI.Core.Interfaces;
@@ -7,8 +8,13 @@ public interface IArticleRepository
     /// <summary>Insère ou remplace un article classifié — idempotent sur Item.SourceId.</summary>
     Task UpsertAsync(Item item, ClassificationResult classification, ContentFetchResult content, DateTimeOffset classifiedAtUtc, CancellationToken cancellationToken);
 
-    /// <summary>Enregistre le résultat de l'application (tags + déplacement éventuel) sur Raindrop.</summary>
-    Task RecordWriteBackAsync(long articleId, bool success, bool moved, DateTimeOffset atUtc, CancellationToken cancellationToken);
+    /// <summary>
+    /// Enregistre le résultat de l'application (tags + déplacement éventuel) sur Raindrop.
+    /// <paramref name="writeBackCollectionId"/> est l'id numérique réellement écrit (<c>null</c> si
+    /// l'article est resté en « Non trié ») — la référence que <c>ReconciliationJob</c> (L3, lot 6)
+    /// compare ensuite à l'état réel pour détecter un déplacement humain.
+    /// </summary>
+    Task RecordWriteBackAsync(long articleId, bool success, bool moved, long? writeBackCollectionId, DateTimeOffset atUtc, CancellationToken cancellationToken);
 
     Task MarkDiscordNotifiedAsync(long articleId, DateTimeOffset notifiedAtUtc, CancellationToken cancellationToken);
 
@@ -24,4 +30,17 @@ public interface IArticleRepository
     /// mensuelle (S4, lot 5).
     /// </summary>
     Task<IReadOnlyList<MonthlyReviewArticle>> GetClassifiedBetweenAsync(DateTimeOffset startUtc, DateTimeOffset endUtc, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Articles à réconcilier (L3, lot 6) : jamais <see cref="LinkStatus.Deleted"/> (tombstone
+    /// définitif), les moins récemment vus en premier (<c>LastSeenAtUtc</c> nulls-first) pour répartir
+    /// la charge sur des passes successives.
+    /// </summary>
+    Task<IReadOnlyList<ReconciliationCandidate>> GetReconciliationCandidatesAsync(int limit, CancellationToken cancellationToken);
+
+    /// <summary>Résultat d'une passe de réconciliation pour un article (L3/L4, lot 6).</summary>
+    Task RecordReconciliationAsync(long articleId, DateTimeOffset lastSeenAtUtc, DateTimeOffset? humanHandledAtUtc, DateTimeOffset? remindedAtUtc, LinkStatus linkStatus, CancellationToken cancellationToken);
+
+    /// <summary>Articles réellement classifiés (jamais un repli), pour les insights N3/N4/L1 (lot 6).</summary>
+    Task<IReadOnlyList<TrackedArticle>> GetTrackedArticlesAsync(CancellationToken cancellationToken);
 }

--- a/src/LoreAI.Core/Interfaces/ICorpusQueryRepository.cs
+++ b/src/LoreAI.Core/Interfaces/ICorpusQueryRepository.cs
@@ -36,4 +36,7 @@ public interface ICorpusQueryRepository
 
     /// <summary>Résumé d'un article classifié (S8, lot 5) — <c>null</c> si l'item n'a jamais été classifié (cas normal pour la majorité de <c>LibraryItems</c>).</summary>
     Task<string?> GetArticleSummaryAsync(long id, CancellationToken cancellationToken);
+
+    /// <summary>File de lecture scorée (L1, lot 6), pour l'outil MCP <c>reading_queue</c> — voir <c>ReadingQueueScorer</c>.</summary>
+    Task<IReadOnlyList<ReadingQueueEntry>> GetReadingQueueAsync(int limit, CancellationToken cancellationToken);
 }

--- a/src/LoreAI.Core/Interfaces/IRaindropClient.cs
+++ b/src/LoreAI.Core/Interfaces/IRaindropClient.cs
@@ -24,4 +24,10 @@ public interface IRaindropClient : ISourceIngester
     /// <see cref="ISourceIngester.GetNewItemsAsync"/>, voir son implémentation Raindrop).
     /// </summary>
     Task<IReadOnlyList<LibraryItem>> GetLibraryPageAsync(int page, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Un raindrop existant par id (L3/<c>ReconciliationJob</c>, lot 6). <c>null</c> si l'item n'existe
+    /// plus (404) — supprimé définitivement de Raindrop, pas seulement mis à la corbeille.
+    /// </summary>
+    Task<RaindropSnapshot?> GetRaindropAsync(long raindropId, CancellationToken cancellationToken);
 }

--- a/src/LoreAI.Core/Interfaces/IReminderNotifier.cs
+++ b/src/LoreAI.Core/Interfaces/IReminderNotifier.cs
@@ -1,0 +1,12 @@
+namespace LoreAI.Core.Interfaces;
+
+/// <summary>
+/// Relance (L4, lot 6) : un article <c>ATester</c>/<c>Haute</c> jamais traité 14 jours après sa
+/// classification. Signature dédiée plutôt que <see cref="IImmediateNotifier"/> : cette relance part
+/// d'un article persisté (<c>ReconciliationJob</c>), pas d'un <c>Item</c>/<c>ClassificationResult</c>
+/// frais issu du pipeline de classification.
+/// </summary>
+public interface IReminderNotifier
+{
+    Task NotifyAsync(string title, string url, int daysSinceClassified, CancellationToken cancellationToken);
+}

--- a/src/LoreAI.Core/Interfaces/IToolRepository.cs
+++ b/src/LoreAI.Core/Interfaces/IToolRepository.cs
@@ -8,5 +8,5 @@ namespace LoreAI.Core.Interfaces;
 /// </summary>
 public interface IToolRepository
 {
-    Task UpsertFromArticleAsync(string name, string? category, long articleId, DateTimeOffset seenAtUtc, CancellationToken cancellationToken);
+    Task UpsertFromArticleAsync(string name, string? category, string? url, long articleId, DateTimeOffset seenAtUtc, CancellationToken cancellationToken);
 }

--- a/src/LoreAI.Core/Models/BrokenTrackedArticle.cs
+++ b/src/LoreAI.Core/Models/BrokenTrackedArticle.cs
@@ -1,0 +1,6 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Core.Models;
+
+/// <summary>Article suivi (jamais un repli) dont le lien est cassé ou supprimé (N3, lot 6).</summary>
+public sealed record BrokenTrackedArticle(long Id, string Title, string Url, LinkStatus LinkStatus);

--- a/src/LoreAI.Core/Models/ClassificationResult.cs
+++ b/src/LoreAI.Core/Models/ClassificationResult.cs
@@ -25,6 +25,9 @@ public sealed record ClassificationResult(
     /// <summary>Catégorie libre de l'outil (S7, lot 5), même condition que <see cref="ToolName"/>.</summary>
     public string? ToolCategory { get; init; }
 
+    /// <summary>Lien vers le dépôt/site officiel de l'outil (S9, lot 6), même condition que <see cref="ToolName"/>.</summary>
+    public string? ToolUrl { get; init; }
+
     public static ClassificationResult Fallback(string model, string reason, string rawResponse) =>
         new(null, [], RecommendedAction.Reference, Priority.Basse, reason, string.Empty, model, rawResponse) { IsFallback = true };
 }

--- a/src/LoreAI.Core/Models/RaindropSnapshot.cs
+++ b/src/LoreAI.Core/Models/RaindropSnapshot.cs
@@ -1,0 +1,4 @@
+namespace LoreAI.Core.Models;
+
+/// <summary>État courant d'un raindrop existant, tel que lu par <c>IRaindropClient.GetRaindropAsync</c> (L3, lot 6).</summary>
+public sealed record RaindropSnapshot(long Id, long? CollectionId, IReadOnlyList<string> Tags, bool Broken);

--- a/src/LoreAI.Core/Models/ReadingQueueEntry.cs
+++ b/src/LoreAI.Core/Models/ReadingQueueEntry.cs
@@ -1,0 +1,6 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Core.Models;
+
+/// <summary>Entrée de la file de lecture scorée (L1, lot 6) — priorité × fraîcheur × temps de lecture.</summary>
+public sealed record ReadingQueueEntry(long Id, string Title, string Url, double Score, int? EstimatedMinutes, Priority Priority, DateTimeOffset CapturedAtUtc);

--- a/src/LoreAI.Core/Models/ReconciliationCandidate.cs
+++ b/src/LoreAI.Core/Models/ReconciliationCandidate.cs
@@ -1,0 +1,21 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Core.Models;
+
+/// <summary>
+/// Article à réconcilier (L3, lot 6) : assez de contexte pour reconstituer ce que LoreAI a réellement
+/// écrit dans Raindrop (tags fusionnés = <see cref="OriginalTags"/> ∪ <see cref="SuggestedTags"/>,
+/// collection = <see cref="WriteBackCollectionId"/>) et décider d'une relance (L4).
+/// </summary>
+public sealed record ReconciliationCandidate(
+    long Id,
+    string Title,
+    string Url,
+    IReadOnlyList<string> OriginalTags,
+    IReadOnlyList<string> SuggestedTags,
+    long? WriteBackCollectionId,
+    RecommendedAction Action,
+    Priority Priority,
+    DateTimeOffset? ClassifiedAtUtc,
+    DateTimeOffset? HumanHandledAtUtc,
+    DateTimeOffset? RemindedAtUtc);

--- a/src/LoreAI.Core/Models/StaleArticle.cs
+++ b/src/LoreAI.Core/Models/StaleArticle.cs
@@ -1,0 +1,4 @@
+namespace LoreAI.Core.Models;
+
+/// <summary>Article « À lire » jamais traité depuis longtemps (N4, lot 6) — proposition de purge, jamais une suppression.</summary>
+public sealed record StaleArticle(long Id, string Title, string Url, int DaysSinceCaptured);

--- a/src/LoreAI.Core/Models/ToolCard.cs
+++ b/src/LoreAI.Core/Models/ToolCard.cs
@@ -12,4 +12,5 @@ public sealed record ToolCard(
     string? Verdict,
     DateTimeOffset FirstSeenAtUtc,
     DateTimeOffset LastSeenAtUtc,
-    IReadOnlyList<ToolRelatedArticle> RelatedArticles);
+    IReadOnlyList<ToolRelatedArticle> RelatedArticles,
+    string? Url = null);

--- a/src/LoreAI.Core/Models/TrackedArticle.cs
+++ b/src/LoreAI.Core/Models/TrackedArticle.cs
@@ -1,0 +1,19 @@
+using LoreAI.Core.Enums;
+
+namespace LoreAI.Core.Models;
+
+/// <summary>
+/// Projection d'un article classifié (jamais un repli) pour les insights N3 (liens morts), N4
+/// (péremption) et L1 (file de lecture scorée) — lot 6.
+/// </summary>
+public sealed record TrackedArticle(
+    long Id,
+    string Title,
+    string Url,
+    RecommendedAction Action,
+    Priority Priority,
+    DateTimeOffset CapturedAtUtc,
+    DateTimeOffset? ClassifiedAtUtc,
+    int? WordCount,
+    DateTimeOffset? HumanHandledAtUtc,
+    LinkStatus? LinkStatus);

--- a/src/LoreAI.Core/Models/WeeklyInsightsReport.cs
+++ b/src/LoreAI.Core/Models/WeeklyInsightsReport.cs
@@ -1,9 +1,11 @@
 namespace LoreAI.Core.Models;
 
 /// <summary>
-/// Agrégat des cinq scénarios de l'axe « Opérer »/« Nettoyer »/« Synthétiser » livrés au lot 2 (#43) :
-/// N1 (doublons), N2 (hygiène des tags), N5 (collections déséquilibrées), S3 (tendances), S6 (coût LLM).
-/// Produit par <c>WeeklyInsightsJob</c>, mis en forme par <c>MarkdownReportBuilder</c>.
+/// Agrégat des scénarios de l'axe « Opérer »/« Nettoyer »/« Synthétiser » : N1 (doublons), N2 (hygiène
+/// des tags), N5 (collections déséquilibrées), S3 (tendances), S6 (coût LLM) livrés au lot 2 (#43), et
+/// N3 (liens morts suivis), N4 (péremption), L1 (file de lecture scorée) ajoutés au lot 6 (#47), tous
+/// alimentés par L3 (<c>ReconciliationJob</c>). Produit par <c>WeeklyInsightsJob</c>, mis en forme par
+/// <c>MarkdownReportBuilder</c>.
 /// </summary>
 public sealed record WeeklyInsightsReport(
     IReadOnlyList<DuplicateUrlGroup> DuplicateUrls,
@@ -12,4 +14,7 @@ public sealed record WeeklyInsightsReport(
     IReadOnlyList<DomainTrend> TopDomains,
     IReadOnlyList<TagTrend> TopTags,
     LlmUsageSummary LlmUsage,
+    IReadOnlyList<BrokenTrackedArticle> BrokenTrackedArticles,
+    IReadOnlyList<StaleArticle> StaleArticles,
+    IReadOnlyList<ReadingQueueEntry> ReadingQueue,
     DateTimeOffset GeneratedAtUtc);

--- a/src/LoreAI.Core/Services/BrokenTrackedArticlesAnalyzer.cs
+++ b/src/LoreAI.Core/Services/BrokenTrackedArticlesAnalyzer.cs
@@ -1,0 +1,21 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Services;
+
+/// <summary>
+/// N3 (lot 6) : liens morts ou supprimés parmi les articles suivis par le pipeline — une vue plus
+/// étroite et actionnable que <c>LibraryItems.Broken</c> (toute la bibliothèque), alimentée par
+/// <c>LinkStatus</c> (L3). Pure — aucun appel réseau.
+/// </summary>
+public static class BrokenTrackedArticlesAnalyzer
+{
+    public static IReadOnlyList<BrokenTrackedArticle> Detect(IReadOnlyList<TrackedArticle> articles)
+    {
+        return articles
+            .Where(a => a.LinkStatus is LinkStatus.Broken or LinkStatus.Deleted)
+            .Select(a => new BrokenTrackedArticle(a.Id, a.Title, a.Url, a.LinkStatus!.Value))
+            .OrderBy(a => a.Title, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+}

--- a/src/LoreAI.Core/Services/ReadingQueueScorer.cs
+++ b/src/LoreAI.Core/Services/ReadingQueueScorer.cs
@@ -1,0 +1,50 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Services;
+
+/// <summary>
+/// L1 (lot 6) : file de lecture scorée sur des données enfin complètes — priorité × fraîcheur × temps
+/// de lecture, filtrée aux articles non traités (<c>HumanHandledAtUtc</c> nul, L3) et pas supprimés.
+/// Remplace le filet perdu à la suppression du digest email (lot 2, D3) : « lis ça » plutôt que « voici
+/// tout ». Pure — aucun appel réseau.
+/// </summary>
+public static class ReadingQueueScorer
+{
+    private static readonly TimeSpan FreshnessWindow = TimeSpan.FromDays(90);
+
+    public static IReadOnlyList<ReadingQueueEntry> Score(IReadOnlyList<TrackedArticle> articles, DateTimeOffset now, int limit)
+    {
+        return articles
+            .Where(a => a.HumanHandledAtUtc is null && a.LinkStatus != LinkStatus.Deleted)
+            .Select(a => ToEntry(a, now))
+            .OrderByDescending(e => e.Score)
+            .Take(limit)
+            .ToList();
+    }
+
+    private static ReadingQueueEntry ToEntry(TrackedArticle article, DateTimeOffset now)
+    {
+        var estimatedMinutes = ReadingTimeEstimator.EstimateMinutes(article.WordCount);
+        var score = ComputeScore(article, now, estimatedMinutes);
+        return new ReadingQueueEntry(article.Id, article.Title, article.Url, score, estimatedMinutes, article.Priority, article.CapturedAtUtc);
+    }
+
+    private static double ComputeScore(TrackedArticle article, DateTimeOffset now, int? estimatedMinutes)
+    {
+        var priorityWeight = article.Priority switch
+        {
+            Priority.Haute => 3.0,
+            Priority.Moyenne => 2.0,
+            _ => 1.0,
+        };
+
+        var daysSinceCaptured = (now - article.CapturedAtUtc).TotalDays;
+        var freshnessFactor = Math.Max(0.0, 1.0 - daysSinceCaptured / FreshnessWindow.TotalDays);
+
+        // Lecture courte légèrement favorisée ; temps de lecture inconnu ni pénalisé ni avantagé.
+        var readingTimeFactor = estimatedMinutes is int minutes ? 30.0 / (30.0 + minutes) : 0.7;
+
+        return priorityWeight * freshnessFactor * readingTimeFactor;
+    }
+}

--- a/src/LoreAI.Core/Services/StaleArticlesAnalyzer.cs
+++ b/src/LoreAI.Core/Services/StaleArticlesAnalyzer.cs
@@ -1,0 +1,22 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Core.Services;
+
+/// <summary>
+/// N4 (lot 6) : articles « À lire » jamais traités (<c>HumanHandledAtUtc</c> nul, L3) au-delà du seuil
+/// de péremption. Proposition seule, jamais de suppression automatique. Pure — aucun appel réseau.
+/// </summary>
+public static class StaleArticlesAnalyzer
+{
+    private static readonly TimeSpan StalenessThreshold = TimeSpan.FromDays(90);
+
+    public static IReadOnlyList<StaleArticle> Detect(IReadOnlyList<TrackedArticle> articles, DateTimeOffset now)
+    {
+        return articles
+            .Where(a => a.Action == RecommendedAction.ALire && a.HumanHandledAtUtc is null && now - a.CapturedAtUtc >= StalenessThreshold)
+            .Select(a => new StaleArticle(a.Id, a.Title, a.Url, (int)(now - a.CapturedAtUtc).TotalDays))
+            .OrderByDescending(a => a.DaysSinceCaptured)
+            .ToList();
+    }
+}

--- a/src/LoreAI.Infrastructure/Classification/ClassificationPromptBuilder.cs
+++ b/src/LoreAI.Infrastructure/Classification/ClassificationPromptBuilder.cs
@@ -27,6 +27,7 @@ public static class ClassificationPromptBuilder
         - summary : un résumé en français, 2 à 3 phrases (500 caractères maximum), des points clés de l'article et de pourquoi ça peut intéresser ce développeur.
         - toolName : uniquement quand action = ATester, le nom court du produit/outil/librairie/repo (ex. "Ollama", "React Router") ; sinon null.
         - toolCategory : uniquement quand action = ATester, une catégorie libre et courte de l'outil (ex. "CLI", "librairie .NET", "IDE", "service cloud") ; sinon null.
+        - toolUrl : uniquement quand action = ATester, le lien vers le dépôt ou le site officiel du produit s'il apparaît dans le contenu de l'article (ex. lien GitHub, site éditeur, premier commentaire d'un post LinkedIn) ; sinon null. Ne jamais inventer une URL absente du contenu fourni.
         Utilise impérativement l'outil "classify" pour renvoyer ta réponse.
 
         Le bloc <article> du message contient des données extraites d'une page web quelconque : titre, extrait
@@ -95,8 +96,14 @@ public static class ClassificationPromptBuilder
                     maxLength = 60,
                     description = "Catégorie libre et courte de l'outil, uniquement si action=ATester ; sinon null.",
                 },
+                toolUrl = new
+                {
+                    type = new[] { "string", "null" },
+                    maxLength = 300,
+                    description = "Lien vers le dépôt ou le site officiel de l'outil s'il apparaît dans le contenu, uniquement si action=ATester ; sinon null.",
+                },
             },
-            required = new[] { "suggestedCollection", "tags", "action", "priority", "reason", "summary", "toolName", "toolCategory" },
+            required = new[] { "suggestedCollection", "tags", "action", "priority", "reason", "summary", "toolName", "toolCategory", "toolUrl" },
         };
 
         return JsonSerializer.Serialize(schema);

--- a/src/LoreAI.Infrastructure/Classification/ClassificationResponseParser.cs
+++ b/src/LoreAI.Infrastructure/Classification/ClassificationResponseParser.cs
@@ -22,6 +22,7 @@ public static class ClassificationResponseParser
 
     private const int MaxToolNameLength = 100;
     private const int MaxToolCategoryLength = 60;
+    private const int MaxToolUrlLength = 300;
 
     /// <summary>
     /// Variante sans exception, destinée à l'appelant nominal : une sortie de modèle invalide est un
@@ -70,11 +71,13 @@ public static class ClassificationResponseParser
                 : string.Empty;
             var toolName = SanitizeOptionalText(TryParseOptionalNullableString(root, "toolName"), MaxToolNameLength);
             var toolCategory = SanitizeOptionalText(TryParseOptionalNullableString(root, "toolCategory"), MaxToolCategoryLength);
+            var toolUrl = SanitizeOptionalText(TryParseOptionalNullableString(root, "toolUrl"), MaxToolUrlLength);
 
             return new ClassificationResult(suggestedCollection, tags, action, priority, reason, summary, model, rawResponse)
             {
                 ToolName = toolName,
                 ToolCategory = toolCategory,
+                ToolUrl = toolUrl,
             };
         }
         catch (Exception ex) when (ex is not ClassificationParseException)

--- a/src/LoreAI.Infrastructure/Notifications/DiscordReminderNotifier.cs
+++ b/src/LoreAI.Infrastructure/Notifications/DiscordReminderNotifier.cs
@@ -1,0 +1,39 @@
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LoreAI.Core.Interfaces;
+
+namespace LoreAI.Infrastructure.Notifications;
+
+/// <summary>
+/// Relance (L4, lot 6), déclenchée par <c>ReconciliationJob</c>. Même patron que
+/// <see cref="DiscordNotifier"/> : n'échoue jamais bruyamment, une panne Discord ne doit pas
+/// interrompre la passe de réconciliation.
+/// </summary>
+public sealed class DiscordReminderNotifier : IReminderNotifier
+{
+    private readonly HttpClient _httpClient;
+    private readonly DiscordOptions _options;
+    private readonly ILogger<DiscordReminderNotifier> _logger;
+
+    public DiscordReminderNotifier(HttpClient httpClient, IOptions<DiscordOptions> options, ILogger<DiscordReminderNotifier> logger)
+    {
+        _httpClient = httpClient;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    public async Task NotifyAsync(string title, string url, int daysSinceClassified, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var payload = new { content = $"**Rappel** — toujours pas traité {daysSinceClassified} jours après classification.\n{title}\n{url}" };
+            var response = await _httpClient.PostAsJsonAsync(_options.WebhookUrl, payload, cancellationToken);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Échec de l'envoi de la relance Discord pour {Url}", url);
+        }
+    }
+}

--- a/src/LoreAI.Infrastructure/Notifications/MarkdownReportBuilder.cs
+++ b/src/LoreAI.Infrastructure/Notifications/MarkdownReportBuilder.cs
@@ -18,8 +18,72 @@ public static class MarkdownReportBuilder
         AppendUnbalancedCollections(builder, report.UnbalancedCollections);
         AppendTrends(builder, report.TopDomains, report.TopTags);
         AppendLlmUsage(builder, report.LlmUsage);
+        AppendBrokenTrackedArticles(builder, report.BrokenTrackedArticles);
+        AppendStaleArticles(builder, report.StaleArticles);
+        AppendReadingQueue(builder, report.ReadingQueue);
 
         return builder.ToString();
+    }
+
+    private static void AppendBrokenTrackedArticles(StringBuilder builder, IReadOnlyList<BrokenTrackedArticle> articles)
+    {
+        builder.AppendLine("## Liens morts parmi les articles suivis (N3)");
+        builder.AppendLine();
+
+        if (articles.Count == 0)
+        {
+            builder.AppendLine("Aucun.");
+            builder.AppendLine();
+            return;
+        }
+
+        foreach (var article in articles)
+        {
+            builder.AppendLine(CultureInfo.InvariantCulture, $"- [{article.Title}]({article.Url}) — {article.LinkStatus}");
+        }
+
+        builder.AppendLine();
+    }
+
+    private static void AppendStaleArticles(StringBuilder builder, IReadOnlyList<StaleArticle> articles)
+    {
+        builder.AppendLine("## Articles périmés — proposition de purge (N4)");
+        builder.AppendLine();
+
+        if (articles.Count == 0)
+        {
+            builder.AppendLine("Aucun.");
+            builder.AppendLine();
+            return;
+        }
+
+        foreach (var article in articles)
+        {
+            builder.AppendLine(CultureInfo.InvariantCulture, $"- [{article.Title}]({article.Url}) — {article.DaysSinceCaptured} jours sans traitement");
+        }
+
+        builder.AppendLine();
+    }
+
+    private static void AppendReadingQueue(StringBuilder builder, IReadOnlyList<ReadingQueueEntry> entries)
+    {
+        builder.AppendLine("## File de lecture (L1)");
+        builder.AppendLine();
+
+        if (entries.Count == 0)
+        {
+            builder.AppendLine("Rien à lire cette semaine.");
+            builder.AppendLine();
+            return;
+        }
+
+        foreach (var entry in entries)
+        {
+            var readingTime = entry.EstimatedMinutes is int minutes ? $"{minutes} min" : "durée inconnue";
+            builder.AppendLine(CultureInfo.InvariantCulture, $"- [{entry.Title}]({entry.Url}) — {entry.Priority}, {readingTime}");
+        }
+
+        builder.AppendLine();
     }
 
     private static void AppendDuplicates(StringBuilder builder, IReadOnlyList<DuplicateUrlGroup> groups)

--- a/src/LoreAI.Infrastructure/Notifications/MarkdownReportBuilder.cs
+++ b/src/LoreAI.Infrastructure/Notifications/MarkdownReportBuilder.cs
@@ -209,6 +209,11 @@ public static class MarkdownReportBuilder
         builder.AppendLine(CultureInfo.InvariantCulture, $"category: {card.Category ?? "—"}");
         builder.AppendLine(CultureInfo.InvariantCulture, $"status: {card.Status}");
         builder.AppendLine(CultureInfo.InvariantCulture, $"verdict: {card.Verdict ?? "(à déterminer)"}");
+        if (!string.IsNullOrEmpty(card.Url))
+        {
+            builder.AppendLine(CultureInfo.InvariantCulture, $"url: {card.Url}");
+        }
+
         builder.AppendLine(CultureInfo.InvariantCulture, $"first_seen: {card.FirstSeenAtUtc:yyyy-MM-dd}");
         builder.AppendLine(CultureInfo.InvariantCulture, $"last_seen: {card.LastSeenAtUtc:yyyy-MM-dd}");
         builder.AppendLine("---");

--- a/src/LoreAI.Infrastructure/Persistence/ArticleEntity.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ArticleEntity.cs
@@ -60,7 +60,8 @@ public sealed class ArticleEntity
     public int? WordCount { get; set; }
     public string? Summary { get; set; }
 
-    // S7 (lot 5) : uniquement renseignés quand RecommendedAction == ATester, cf. ClassificationResult.
+    // S7 (lot 5) / S9 (lot 6) : uniquement renseignés quand RecommendedAction == ATester, cf. ClassificationResult.
     public string? ToolName { get; set; }
     public string? ToolCategory { get; set; }
+    public string? ToolUrl { get; set; }
 }

--- a/src/LoreAI.Infrastructure/Persistence/ArticleEntity.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ArticleEntity.cs
@@ -39,6 +39,19 @@ public sealed class ArticleEntity
     public DateTimeOffset? WriteBackAtUtc { get; set; }
     public DateTimeOffset? DiscordNotifiedAtUtc { get; set; }
 
+    // Id de collection réellement écrit au write-back (null = resté en Non trié) — la référence que
+    // ReconciliationJob (L3, lot 6) compare à l'état réel pour détecter un déplacement humain.
+    public long? WriteBackCollectionId { get; set; }
+
+    // L3 (lot 6) : null tant qu'aucune passe de réconciliation n'a eu lieu, distinct de LinkStatus.Ok
+    // qui est une constatation positive. HumanHandledAtUtc n'est jamais réinitialisé une fois posé.
+    public DateTimeOffset? LastSeenAtUtc { get; set; }
+    public DateTimeOffset? HumanHandledAtUtc { get; set; }
+    public LinkStatus? LinkStatus { get; set; }
+
+    // L4 (lot 6) : relance envoyée une seule fois.
+    public DateTimeOffset? RemindedAtUtc { get; set; }
+
     // Contenu réel (S1, lot 4) : toujours nullable, alimenté au mieux (best-effort) — un article
     // pré-lot-4 ou dont le fetch a échoué n'a simplement jamais ces champs renseignés.
     public string? ContentText { get; set; }

--- a/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
@@ -82,7 +82,7 @@ public sealed class ArticleRepository : IArticleRepository
         }
     }
 
-    public async Task RecordWriteBackAsync(long articleId, bool success, bool moved, DateTimeOffset atUtc, CancellationToken cancellationToken)
+    public async Task RecordWriteBackAsync(long articleId, bool success, bool moved, long? writeBackCollectionId, DateTimeOffset atUtc, CancellationToken cancellationToken)
     {
         await _schemaGuard.EnsureMigratedAsync(cancellationToken);
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
@@ -95,6 +95,7 @@ public sealed class ArticleRepository : IArticleRepository
                 setters => setters
                     .SetProperty(a => a.WriteBackStatus, success ? "Done" : "Failed")
                     .SetProperty(a => a.Moved, moved)
+                    .SetProperty(a => a.WriteBackCollectionId, writeBackCollectionId)
                     .SetProperty(a => a.WriteBackAtUtc, atUtc),
                 cancellationToken);
 
@@ -137,6 +138,55 @@ public sealed class ArticleRepository : IArticleRepository
         return await context.Articles
             .Where(a => !a.IsFallback && a.ClassifiedAtUtc != null && a.ClassifiedAtUtc >= startUtc && a.ClassifiedAtUtc < endUtc)
             .Select(a => new MonthlyReviewArticle(a.Id, a.Title, a.Url, a.SuggestedCollection, a.SuggestedTags, a.Summary, a.Reason, a.Priority))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<ReconciliationCandidate>> GetReconciliationCandidatesAsync(int limit, CancellationToken cancellationToken)
+    {
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.Articles
+            .Where(a => a.LinkStatus != LinkStatus.Deleted)
+            .OrderBy(a => a.LastSeenAtUtc)
+            .Take(limit)
+            .Select(a => new ReconciliationCandidate(
+                a.Id, a.Title, a.Url, a.OriginalTags, a.SuggestedTags, a.WriteBackCollectionId,
+                a.RecommendedAction, a.Priority, a.ClassifiedAtUtc, a.HumanHandledAtUtc, a.RemindedAtUtc))
+            .ToListAsync(cancellationToken);
+    }
+
+    public async Task RecordReconciliationAsync(long articleId, DateTimeOffset lastSeenAtUtc, DateTimeOffset? humanHandledAtUtc, DateTimeOffset? remindedAtUtc, LinkStatus linkStatus, CancellationToken cancellationToken)
+    {
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var affected = await context.Articles
+            .Where(a => a.Id == articleId)
+            .ExecuteUpdateAsync(
+                setters => setters
+                    .SetProperty(a => a.LastSeenAtUtc, lastSeenAtUtc)
+                    .SetProperty(a => a.HumanHandledAtUtc, humanHandledAtUtc)
+                    .SetProperty(a => a.RemindedAtUtc, remindedAtUtc)
+                    .SetProperty(a => a.LinkStatus, linkStatus),
+                cancellationToken);
+
+        if (affected == 0)
+        {
+            _logger.LogWarning("Réconciliation non enregistrée : aucun article {ArticleId} en base.", articleId);
+        }
+    }
+
+    public async Task<IReadOnlyList<TrackedArticle>> GetTrackedArticlesAsync(CancellationToken cancellationToken)
+    {
+        await _schemaGuard.EnsureMigratedAsync(cancellationToken);
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        return await context.Articles
+            .Where(a => !a.IsFallback)
+            .Select(a => new TrackedArticle(
+                a.Id, a.Title, a.Url, a.RecommendedAction, a.Priority, a.CapturedAtUtc,
+                a.ClassifiedAtUtc, a.WordCount, a.HumanHandledAtUtc, a.LinkStatus))
             .ToListAsync(cancellationToken);
     }
 }

--- a/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
@@ -50,6 +50,7 @@ public sealed class ArticleRepository : IArticleRepository
         entity.IsFallback = classification.IsFallback;
         entity.ToolName = classification.ToolName;
         entity.ToolCategory = classification.ToolCategory;
+        entity.ToolUrl = classification.ToolUrl;
         entity.ClassificationModel = classification.Model;
         entity.ClassificationRawResponse = NormalizeToJson(classification.RawResponse);
         entity.ClassifiedAtUtc = classifiedAtUtc;

--- a/src/LoreAI.Infrastructure/Persistence/CorpusQueryRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/CorpusQueryRepository.cs
@@ -130,7 +130,7 @@ public sealed class CorpusQueryRepository : ICorpusQueryRepository
             .Select(a => new ToolRelatedArticle(a.Id, a.Title, a.Url, a.Summary))
             .ToListAsync(cancellationToken);
 
-        return new ToolCard(tool.Id, tool.Name, tool.Category, tool.Status, tool.Verdict, tool.FirstSeenAtUtc, tool.LastSeenAtUtc, relatedArticles);
+        return new ToolCard(tool.Id, tool.Name, tool.Category, tool.Status, tool.Verdict, tool.FirstSeenAtUtc, tool.LastSeenAtUtc, relatedArticles, tool.Url);
     }
 
     public async Task<string?> GetArticleSummaryAsync(long id, CancellationToken cancellationToken)

--- a/src/LoreAI.Infrastructure/Persistence/CorpusQueryRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/CorpusQueryRepository.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using LoreAI.Core.Interfaces;
 using LoreAI.Core.Models;
+using LoreAI.Core.Services;
 
 namespace LoreAI.Infrastructure.Persistence;
 
@@ -140,6 +141,21 @@ public sealed class CorpusQueryRepository : ICorpusQueryRepository
             .Where(a => a.Id == id)
             .Select(a => a.Summary)
             .SingleOrDefaultAsync(cancellationToken);
+    }
+
+    /// <summary>L1 (lot 6) : projection puis scoring en mémoire (<see cref="ReadingQueueScorer"/>) — le corpus suivi reste petit face à toute la bibliothèque, pas besoin de traduire le score en SQL.</summary>
+    public async Task<IReadOnlyList<ReadingQueueEntry>> GetReadingQueueAsync(int limit, CancellationToken cancellationToken)
+    {
+        await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
+
+        var trackedArticles = await context.Articles
+            .Where(a => !a.IsFallback)
+            .Select(a => new TrackedArticle(
+                a.Id, a.Title, a.Url, a.RecommendedAction, a.Priority, a.CapturedAtUtc,
+                a.ClassifiedAtUtc, a.WordCount, a.HumanHandledAtUtc, a.LinkStatus))
+            .ToListAsync(cancellationToken);
+
+        return ReadingQueueScorer.Score(trackedArticles, DateTimeOffset.UtcNow, limit);
     }
 
     private static readonly System.Linq.Expressions.Expression<Func<LibraryItemEntity, LibraryItemSummary>> ToSummary =

--- a/src/LoreAI.Infrastructure/Persistence/LoreAiDbContext.cs
+++ b/src/LoreAI.Infrastructure/Persistence/LoreAiDbContext.cs
@@ -21,6 +21,7 @@ public sealed class LoreAiDbContext(DbContextOptions<LoreAiDbContext> options) :
             article.Property(a => a.RecommendedAction).HasConversion<string>();
             article.Property(a => a.Priority).HasConversion<string>();
             article.Property(a => a.ContentStatus).HasConversion<string>();
+            article.Property(a => a.LinkStatus).HasConversion<string>();
             article.HasIndex(a => a.CapturedAtUtc);
         });
 

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260825053559_AddReconciliationFields.Designer.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260825053559_AddReconciliationFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LoreAI.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace LoreAI.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(LoreAiDbContext))]
-    partial class LoreAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825053559_AddReconciliationFields")]
+    partial class AddReconciliationFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260825053559_AddReconciliationFields.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260825053559_AddReconciliationFields.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LoreAI.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddReconciliationFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "HumanHandledAtUtc",
+                table: "Articles",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "LastSeenAtUtc",
+                table: "Articles",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "LinkStatus",
+                table: "Articles",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "RemindedAtUtc",
+                table: "Articles",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "WriteBackCollectionId",
+                table: "Articles",
+                type: "bigint",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HumanHandledAtUtc",
+                table: "Articles");
+
+            migrationBuilder.DropColumn(
+                name: "LastSeenAtUtc",
+                table: "Articles");
+
+            migrationBuilder.DropColumn(
+                name: "LinkStatus",
+                table: "Articles");
+
+            migrationBuilder.DropColumn(
+                name: "RemindedAtUtc",
+                table: "Articles");
+
+            migrationBuilder.DropColumn(
+                name: "WriteBackCollectionId",
+                table: "Articles");
+        }
+    }
+}

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260825054554_AddToolUrl.Designer.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260825054554_AddToolUrl.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LoreAI.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace LoreAI.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(LoreAiDbContext))]
-    partial class LoreAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260825054554_AddToolUrl")]
+    partial class AddToolUrl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/LoreAI.Infrastructure/Persistence/Migrations/20260825054554_AddToolUrl.cs
+++ b/src/LoreAI.Infrastructure/Persistence/Migrations/20260825054554_AddToolUrl.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LoreAI.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddToolUrl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Url",
+                table: "Tools",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ToolUrl",
+                table: "Articles",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Url",
+                table: "Tools");
+
+            migrationBuilder.DropColumn(
+                name: "ToolUrl",
+                table: "Articles");
+        }
+    }
+}

--- a/src/LoreAI.Infrastructure/Persistence/ToolEntity.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ToolEntity.cs
@@ -11,6 +11,9 @@ public sealed class ToolEntity
     public required string Name { get; set; }
     public string? Category { get; set; }
 
+    /// <summary>Lien vers le dépôt/site officiel (S9, lot 6) — même patron que <see cref="Category"/> : renseigné à la création, jamais réécrit ensuite.</summary>
+    public string? Url { get; set; }
+
     /// <summary>
     /// Champ manuel/futur : jamais écrasé par le pipeline de classification, seulement initialisé à la
     /// création (<see cref="ToolRepository"/>). Pas d'enum : rien ne fait encore transitionner ce statut.

--- a/src/LoreAI.Infrastructure/Persistence/ToolRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ToolRepository.cs
@@ -14,7 +14,7 @@ public sealed class ToolRepository : IToolRepository
         _schemaGuard = schemaGuard;
     }
 
-    public async Task UpsertFromArticleAsync(string name, string? category, long articleId, DateTimeOffset seenAtUtc, CancellationToken cancellationToken)
+    public async Task UpsertFromArticleAsync(string name, string? category, string? url, long articleId, DateTimeOffset seenAtUtc, CancellationToken cancellationToken)
     {
         await _schemaGuard.EnsureMigratedAsync(cancellationToken);
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
@@ -26,6 +26,7 @@ public sealed class ToolRepository : IToolRepository
             {
                 Name = name,
                 Category = category,
+                Url = url,
                 RelatedArticleIds = [articleId],
                 FirstSeenAtUtc = seenAtUtc,
                 LastSeenAtUtc = seenAtUtc,

--- a/src/LoreAI.Infrastructure/Raindrop/Dto/RaindropApiDtos.cs
+++ b/src/LoreAI.Infrastructure/Raindrop/Dto/RaindropApiDtos.cs
@@ -10,6 +10,13 @@ internal sealed class RaindropsPageDto
     public int Count { get; set; }
 }
 
+/// <summary>Réponse de <c>GET /raindrop/{id}</c> — un seul item, pas une page (L3, lot 6).</summary>
+internal sealed class RaindropItemResponseDto
+{
+    public bool Result { get; set; }
+    public RaindropDto? Item { get; set; }
+}
+
 internal sealed class RaindropDto
 {
     [JsonPropertyName("_id")]

--- a/src/LoreAI.Infrastructure/Raindrop/RaindropClient.cs
+++ b/src/LoreAI.Infrastructure/Raindrop/RaindropClient.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Microsoft.Extensions.Logging;
@@ -106,6 +107,23 @@ public sealed class RaindropClient : IRaindropClient
             ?? throw new InvalidOperationException("Réponse Raindrop vide ou invalide.");
 
         return payload.Items.Select(MapToLibraryItem).ToList();
+    }
+
+    /// <summary>L3 (lot 6) : <c>null</c> sur 404, sans lever — un item supprimé définitivement de Raindrop est un résultat attendu, pas un incident.</summary>
+    public async Task<RaindropSnapshot?> GetRaindropAsync(long raindropId, CancellationToken cancellationToken)
+    {
+        var response = await _httpClient.GetAsync($"raindrop/{raindropId}", cancellationToken);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            return null;
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var payload = await response.Content.ReadFromJsonAsync<RaindropItemResponseDto>(cancellationToken: cancellationToken);
+        return payload?.Item is { } dto
+            ? new RaindropSnapshot(dto.Id, dto.Collection?.Id, dto.Tags, dto.Broken)
+            : null;
     }
 
     public async Task<RaindropTaxonomy> GetTaxonomyAsync(CancellationToken cancellationToken)

--- a/src/LoreAI.Mcp/Dockerfile
+++ b/src/LoreAI.Mcp/Dockerfile
@@ -25,12 +25,22 @@ RUN DOTNET_ARCH="$(echo "$TARGETARCH" | sed 's/amd64/x64/')" \
 # possible. Le squelette de /data est donc préparé ici, puis copié avec la bonne propriété.
 RUN mkdir -p /app/data-skeleton/logs
 
+# O4 (#71, lot 6) : /usr/share/zoneinfo n'est pas garanti présent sur l'image SDK Debian de base —
+# installé explicitement ici plutôt que supposé, puis copié tel quel vers l'étage chiselé qui n'a pas
+# de gestionnaire de paquets pour le faire lui-même.
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata && rm -rf /var/lib/apt/lists/*
+
 # Chiselée, variante ASP.NET Core (contrairement à LoreAI.Worker : ce process héberge Kestrel, pas
 # seulement le runtime .NET) : pas de shell ni de gestionnaire de paquets, utilisateur non-root par
 # défaut. Multi-arch, dont arm64 pour le Raspberry Pi.
 FROM mcr.microsoft.com/dotnet/aspnet:10.0-noble-chiseled AS final
 WORKDIR /app
 COPY --from=build /app/publish .
+
+# O4 (#71, lot 6) : même traitement que LoreAI.Worker — seul l'horodatage Serilog (heure locale du
+# process) change, aucune valeur UTC de domaine n'en dépend.
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+ENV TZ=Europe/Paris
 
 # /data ne porte que les logs (pas de base ici, ADR 0009) — même convention que LoreAI.Worker. Sur un
 # bind mount, c'est la propriété côté hôte qui prime, voir docs/deploiement-raspberry-pi.md.

--- a/src/LoreAI.Mcp/Tools/CorpusTools.cs
+++ b/src/LoreAI.Mcp/Tools/CorpusTools.cs
@@ -99,6 +99,15 @@ public sealed class CorpusTools
         return MarkdownReportBuilder.BuildItemExport(item, summary);
     }
 
+    [McpServerTool(Name = "reading_queue", ReadOnly = true), Description("File de lecture scorée (L1, lot 6) : priorité × fraîcheur × temps de lecture, articles non traités uniquement.")]
+    public async Task<IReadOnlyList<ReadingQueueEntry>> ReadingQueue(
+        [Description("Nombre maximum d'entrées (défaut 20, max 100).")] int count,
+        CancellationToken cancellationToken)
+    {
+        var clamped = Math.Clamp(count <= 0 ? DefaultSearchLimit : count, 1, MaxSearchLimit);
+        return await _repository.GetReadingQueueAsync(clamped, cancellationToken);
+    }
+
     [McpServerTool(Name = "list_tools", ReadOnly = true), Description("Liste les outils MCP prévus pour ce serveur (issue #44) et leur statut d'implémentation.")]
     public IReadOnlyList<McpToolStatus> ListTools()
     {
@@ -113,7 +122,7 @@ public sealed class CorpusTools
             new McpToolStatus("catalog_tools", "implémenté (S7, lot 5)"),
             new McpToolStatus("tool_card", "implémenté (S7, lot 5)"),
             new McpToolStatus("export_item", "implémenté (S8, lot 5)"),
-            new McpToolStatus("reading_queue", "non implémenté — dépend du scoring du lot 6 (L1)"),
+            new McpToolStatus("reading_queue", "implémenté (L1, lot 6)"),
         ];
     }
 }

--- a/src/LoreAI.Worker/Dockerfile
+++ b/src/LoreAI.Worker/Dockerfile
@@ -25,11 +25,23 @@ RUN DOTNET_ARCH="$(echo "$TARGETARCH" | sed 's/amd64/x64/')" \
 # possible. Le squelette de /data est donc préparé ici, puis copié avec la bonne propriété.
 RUN mkdir -p /app/data-skeleton/logs
 
+# O4 (#71, lot 6) : /usr/share/zoneinfo n'est pas garanti présent sur l'image SDK Debian de base —
+# installé explicitement ici plutôt que supposé, puis copié tel quel vers l'étage chiselé qui n'a pas
+# de gestionnaire de paquets pour le faire lui-même.
+RUN apt-get update && apt-get install -y --no-install-recommends tzdata && rm -rf /var/lib/apt/lists/*
+
 # Chiselée : pas de shell ni de gestionnaire de paquets (surface d'attaque réduite), et l'utilisateur
 # applicatif non-root est déjà celui par défaut. Multi-arch, dont arm64 pour le Raspberry Pi.
 FROM mcr.microsoft.com/dotnet/runtime:10.0-noble-chiseled AS final
 WORKDIR /app
 COPY --from=build /app/publish .
+
+# O4 (#71, lot 6) : seul l'horodatage Serilog (heure locale du process) doit passer à Paris — aucune
+# valeur UTC de domaine (Postgres, noms de fichiers de rapport) n'en dépend, ils utilisent déjà
+# DateTimeOffset.UtcNow explicitement. DOTNET_SYSTEM_GLOBALIZATION_INVARIANT n'affecte pas
+# TimeZoneInfo côté Linux : ce sous-système lit /usr/share/zoneinfo indépendamment d'ICU.
+COPY --from=build /usr/share/zoneinfo /usr/share/zoneinfo
+ENV TZ=Europe/Paris
 
 # /data porte la base SQLite et les logs. Cette propriété ne vaut que pour un volume nommé : sur un
 # bind mount (le cas de docker-compose.yml), c'est la propriété côté hôte qui prime — voir le README.

--- a/src/LoreAI.Worker/Options/WorkerOptions.cs
+++ b/src/LoreAI.Worker/Options/WorkerOptions.cs
@@ -51,4 +51,13 @@ public sealed class WorkerOptions
     /// </summary>
     [Required(AllowEmptyStrings = false)]
     public string MonthlyReviewCronExpression { get; init; } = "0 5 1 * *";
+
+    /// <summary>
+    /// Expression cron de la réconciliation (L3, lot 6) — par défaut chaque jour à 2h UTC, avant
+    /// <see cref="LibraryIndexCronExpression"/> (3h) pour que le rapport hebdomadaire du dimanche lise
+    /// un état frais. Quotidien plutôt qu'hebdomadaire : les seuils de relance (L4, 14j) et de
+    /// péremption (N4, 90j) restent utiles même si le rapport lui-même reste hebdomadaire.
+    /// </summary>
+    [Required(AllowEmptyStrings = false)]
+    public string ReconciliationCronExpression { get; init; } = "0 2 * * *";
 }

--- a/src/LoreAI.Worker/Program.cs
+++ b/src/LoreAI.Worker/Program.cs
@@ -121,6 +121,22 @@ try
         return;
     }
 
+    // O5 (#75, lot 6) : force un passage hors cadence pour les deux jobs à cron lent (hebdo/mensuel),
+    // sans attendre leur prochain déclenchement naturel — même patron que --health-check, avant
+    // host.Run() et sans valider les options non liées. Les deux jobs ne lèvent jamais (philosophie
+    // « jamais throw, toujours logger » déjà en place) : pas de code de sortie dédié à calculer ici.
+    if (args.Contains("--run-weekly-insights"))
+    {
+        await host.Services.GetRequiredService<WeeklyInsightsJob>().Invoke();
+        return;
+    }
+
+    if (args.Contains("--run-monthly-review"))
+    {
+        await host.Services.GetRequiredService<MonthlyReviewJob>().Invoke();
+        return;
+    }
+
     // #65 : seul signal fiable, en dehors des logs applicatifs, pour savoir quelle version tourne réellement
     // sur mcm8 sans avoir à interroger Docker — utile quand un déploiement partiel laisse un conteneur en retard.
     var version = Assembly.GetExecutingAssembly()

--- a/src/LoreAI.Worker/Program.cs
+++ b/src/LoreAI.Worker/Program.cs
@@ -100,11 +100,16 @@ try
     builder.Services.AddHttpClient<IReportNotifier, DiscordReportNotifier>()
         .AddStandardResilienceHandler();
 
+    // Relance L4 (lot 6), déclenchée par ReconciliationJob.
+    builder.Services.AddHttpClient<IReminderNotifier, DiscordReminderNotifier>()
+        .AddStandardResilienceHandler();
+
     builder.Services.AddScheduler();
     builder.Services.AddTransient<UnsortedClassificationJob>();
     builder.Services.AddTransient<LibraryIndexingJob>();
     builder.Services.AddTransient<WeeklyInsightsJob>();
     builder.Services.AddTransient<MonthlyReviewJob>();
+    builder.Services.AddTransient<ReconciliationJob>();
 
     var host = builder.Build();
 
@@ -145,6 +150,10 @@ try
         scheduler.Schedule<MonthlyReviewJob>()
             .Cron(workerOptions.MonthlyReviewCronExpression)
             .PreventOverlapping(nameof(MonthlyReviewJob));
+
+        scheduler.Schedule<ReconciliationJob>()
+            .Cron(workerOptions.ReconciliationCronExpression)
+            .PreventOverlapping(nameof(ReconciliationJob));
     });
 
     host.Run();

--- a/src/LoreAI.Worker/Services/ReconciliationJob.cs
+++ b/src/LoreAI.Worker/Services/ReconciliationJob.cs
@@ -1,0 +1,160 @@
+using Coravel.Invocable;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+
+namespace LoreAI.Worker.Services;
+
+/// <summary>
+/// Le chaînon manquant (L3, lot 6) : re-fetch des items Raindrop suivis pour détecter ce qu'aucun
+/// autre job ne voit — tags/collection modifiés par l'utilisateur (signal « lu »), articles supprimés,
+/// liens cassés. Alimente aussi la relance L4 dans la même passe : pas de raison de reparcourir les
+/// mêmes articles deux fois pour deux décisions qui dépendent du même état.
+/// </summary>
+public sealed class ReconciliationJob : IInvocable, ICancellableInvocable
+{
+    /// <summary>Plafond d'une passe (même esprit que <c>LibraryIndexingJob.MaxPagesPerInvocation</c>) : le cron quotidien reprend le lendemain là où la précédente passe s'est arrêtée (tri par <c>LastSeenAtUtc</c> croissant).</summary>
+    private const int MaxArticlesPerInvocation = 200;
+
+    private static readonly TimeSpan ReminderThreshold = TimeSpan.FromDays(14);
+
+    private readonly IRaindropClient _raindropClient;
+    private readonly IArticleRepository _articleRepository;
+    private readonly IReminderNotifier _reminderNotifier;
+    private readonly ILogger<ReconciliationJob> _logger;
+
+    public ReconciliationJob(
+        IRaindropClient raindropClient,
+        IArticleRepository articleRepository,
+        IReminderNotifier reminderNotifier,
+        ILogger<ReconciliationJob> logger)
+    {
+        _raindropClient = raindropClient;
+        _articleRepository = articleRepository;
+        _reminderNotifier = reminderNotifier;
+        _logger = logger;
+    }
+
+    /// <summary>Alimenté par Coravel, annulé à l'arrêt de l'application (SIGTERM, <c>docker compose down</c>).</summary>
+    public CancellationToken CancellationToken { get; set; }
+
+    public async Task Invoke()
+    {
+        var cancellationToken = CancellationToken;
+
+        try
+        {
+            var candidates = await _articleRepository.GetReconciliationCandidatesAsync(MaxArticlesPerInvocation, cancellationToken);
+            var deletedCount = 0;
+            var brokenCount = 0;
+            var humanHandledCount = 0;
+            var remindedCount = 0;
+
+            foreach (var candidate in candidates)
+            {
+                try
+                {
+                    var now = DateTimeOffset.UtcNow;
+                    var (linkStatus, humanHandledAtUtc) = await ReconcileOneAsync(candidate, now, cancellationToken);
+
+                    if (linkStatus == LinkStatus.Deleted)
+                    {
+                        deletedCount++;
+                    }
+                    else if (linkStatus == LinkStatus.Broken)
+                    {
+                        brokenCount++;
+                    }
+
+                    if (humanHandledAtUtc is not null && candidate.HumanHandledAtUtc is null)
+                    {
+                        humanHandledCount++;
+                    }
+
+                    var remindedAtUtc = candidate.RemindedAtUtc;
+                    if (ShouldRemind(candidate, humanHandledAtUtc, now))
+                    {
+                        await _reminderNotifier.NotifyAsync(candidate.Title, candidate.Url, (int)(now - candidate.ClassifiedAtUtc!.Value).TotalDays, cancellationToken);
+                        remindedAtUtc = now;
+                        remindedCount++;
+                    }
+
+                    await _articleRepository.RecordReconciliationAsync(candidate.Id, now, humanHandledAtUtc, remindedAtUtc, linkStatus, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    if (_logger.IsEnabled(LogLevel.Information))
+                    {
+                        _logger.LogInformation("Réconciliation interrompue par l'arrêt de l'application avant l'article {ArticleId}.", candidate.Id);
+                    }
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    // Un échec réseau isolé sur un article ne doit pas priver les suivants de leur passe :
+                    // contrairement à LibraryIndexingJob (pages séquentielles), chaque article est indépendant.
+                    _logger.LogWarning(ex, "Échec de la réconciliation de l'article {ArticleId} — repris à la prochaine passe.", candidate.Id);
+                }
+            }
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Réconciliation terminée : {Count} articles revus, {DeletedCount} supprimés, {BrokenCount} cassés, {HumanHandledCount} marqués traités, {RemindedCount} relancés.",
+                    candidates.Count,
+                    deletedCount,
+                    brokenCount,
+                    humanHandledCount,
+                    remindedCount);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Réconciliation interrompue par l'arrêt de l'application.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Échec de la passe de réconciliation.");
+        }
+    }
+
+    private async Task<(LinkStatus LinkStatus, DateTimeOffset? HumanHandledAtUtc)> ReconcileOneAsync(
+        ReconciliationCandidate candidate, DateTimeOffset now, CancellationToken cancellationToken)
+    {
+        var snapshot = await _raindropClient.GetRaindropAsync(candidate.Id, cancellationToken);
+        if (snapshot is null)
+        {
+            return (LinkStatus.Deleted, candidate.HumanHandledAtUtc);
+        }
+
+        var linkStatus = snapshot.Broken ? LinkStatus.Broken : LinkStatus.Ok;
+
+        if (candidate.HumanHandledAtUtc is not null)
+        {
+            return (linkStatus, candidate.HumanHandledAtUtc);
+        }
+
+        var expectedTags = candidate.OriginalTags
+            .Concat(candidate.SuggestedTags)
+            .Select(t => t.ToUpperInvariant())
+            .ToHashSet();
+        var actualTags = snapshot.Tags.Select(t => t.ToUpperInvariant()).ToHashSet();
+        var tagsChanged = !expectedTags.SetEquals(actualTags);
+
+        var expectedCollectionId = candidate.WriteBackCollectionId ?? -1L;
+        var actualCollectionId = snapshot.CollectionId ?? -1L;
+        var collectionChanged = expectedCollectionId != actualCollectionId;
+
+        var humanHandledAtUtc = tagsChanged || collectionChanged ? now : (DateTimeOffset?)null;
+        return (linkStatus, humanHandledAtUtc);
+    }
+
+    /// <summary>L4 : une seule relance par article, seulement pour ce qui aurait dû être notifié immédiatement (<c>ATester</c>/<c>Haute</c>) et reste non traité 14 jours après classification.</summary>
+    private static bool ShouldRemind(ReconciliationCandidate candidate, DateTimeOffset? humanHandledAtUtc, DateTimeOffset now) =>
+        candidate.Action == RecommendedAction.ATester
+        && candidate.Priority == Priority.Haute
+        && humanHandledAtUtc is null
+        && candidate.RemindedAtUtc is null
+        && candidate.ClassifiedAtUtc is not null
+        && now - candidate.ClassifiedAtUtc.Value >= ReminderThreshold;
+}

--- a/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
+++ b/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
@@ -307,7 +307,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
             var mergedNote = ClassificationNoteBuilder.Build(item.Note, classification);
 
             await _raindropClient.UpdateRaindropAsync(raindropId, mergedTags, mergedNote, matchedCollection?.Id, cancellationToken);
-            await _articleRepository.RecordWriteBackAsync(raindropId, success: true, moved: matchedCollection is not null, DateTimeOffset.UtcNow, cancellationToken);
+            await _articleRepository.RecordWriteBackAsync(raindropId, success: true, moved: matchedCollection is not null, matchedCollection?.Id, DateTimeOffset.UtcNow, cancellationToken);
 
             // Ne compte que les tags réellement nouveaux (fusion insensible à la casse) : un tag déjà
             // présent sur l'article ne doit pas gonfler le compteur du journal de cycle.
@@ -317,7 +317,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Échec de l'application des tags/déplacement pour l'item {SourceId}", item.SourceId);
-            await _articleRepository.RecordWriteBackAsync(raindropId, success: false, moved: false, DateTimeOffset.UtcNow, cancellationToken);
+            await _articleRepository.RecordWriteBackAsync(raindropId, success: false, moved: false, writeBackCollectionId: null, DateTimeOffset.UtcNow, cancellationToken);
             return new WriteBackOutcome(Moved: false, TagsAdded: 0);
         }
     }

--- a/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
+++ b/src/LoreAI.Worker/Services/UnsortedClassificationJob.cs
@@ -336,7 +336,7 @@ public sealed class UnsortedClassificationJob : IInvocable, ICancellableInvocabl
 
         try
         {
-            await _toolRepository.UpsertFromArticleAsync(classification.ToolName, classification.ToolCategory, ParseRaindropId(item), DateTimeOffset.UtcNow, cancellationToken);
+            await _toolRepository.UpsertFromArticleAsync(classification.ToolName, classification.ToolCategory, classification.ToolUrl, ParseRaindropId(item), DateTimeOffset.UtcNow, cancellationToken);
         }
         catch (Exception ex)
         {

--- a/src/LoreAI.Worker/Services/WeeklyInsightsJob.cs
+++ b/src/LoreAI.Worker/Services/WeeklyInsightsJob.cs
@@ -16,6 +16,9 @@ public sealed class WeeklyInsightsJob : IInvocable, ICancellableInvocable
 {
     private static readonly TimeSpan TrendWindow = TimeSpan.FromDays(30);
 
+    /// <summary>Nombre d'entrées de la file de lecture (L1, lot 6) incluses dans le rapport hebdomadaire.</summary>
+    private const int ReadingQueueSize = 10;
+
     private readonly ILibraryItemRepository _libraryItemRepository;
     private readonly IArticleRepository _articleRepository;
     private readonly IRaindropClient _raindropClient;
@@ -50,6 +53,7 @@ public sealed class WeeklyInsightsJob : IInvocable, ICancellableInvocable
             var taxonomy = await _raindropClient.GetTaxonomyAsync(cancellationToken);
             var startOfMonthUtc = new DateTimeOffset(generatedAtUtc.Year, generatedAtUtc.Month, 1, 0, 0, 0, TimeSpan.Zero);
             var rawResponses = await _articleRepository.GetClassificationRawResponsesSinceAsync(startOfMonthUtc, cancellationToken);
+            var trackedArticles = await _articleRepository.GetTrackedArticlesAsync(cancellationToken);
 
             var collectionTitles = taxonomy.Collections.ToDictionary(c => c.Id, c => c.Title);
             var recentItems = libraryItems.Where(i => generatedAtUtc - i.CapturedAtUtc <= TrendWindow).ToList();
@@ -61,6 +65,9 @@ public sealed class WeeklyInsightsJob : IInvocable, ICancellableInvocable
                 TrendAnalyzer.TopDomains(recentItems),
                 TrendAnalyzer.TopTags(recentItems),
                 LlmUsageAnalyzer.Analyze(rawResponses),
+                BrokenTrackedArticlesAnalyzer.Detect(trackedArticles),
+                StaleArticlesAnalyzer.Detect(trackedArticles, generatedAtUtc),
+                ReadingQueueScorer.Score(trackedArticles, generatedAtUtc, ReadingQueueSize),
                 generatedAtUtc);
 
             var markdown = MarkdownReportBuilder.Build(report);
@@ -70,11 +77,14 @@ public sealed class WeeklyInsightsJob : IInvocable, ICancellableInvocable
             if (_logger.IsEnabled(LogLevel.Information))
             {
                 _logger.LogInformation(
-                    "Rapport hebdomadaire envoyé : {DuplicateCount} doublons, {ClusterCount} grappes de tags, {UnbalancedCount} collections déséquilibrées, {ClassificationCount} classifications ce mois-ci.",
+                    "Rapport hebdomadaire envoyé : {DuplicateCount} doublons, {ClusterCount} grappes de tags, {UnbalancedCount} collections déséquilibrées, {ClassificationCount} classifications ce mois-ci, {BrokenCount} liens morts suivis, {StaleCount} articles périmés, {QueueCount} entrées en file de lecture.",
                     report.DuplicateUrls.Count,
                     report.TagHygiene.Clusters.Count,
                     report.UnbalancedCollections.Count,
-                    report.LlmUsage.ClassificationCount);
+                    report.LlmUsage.ClassificationCount,
+                    report.BrokenTrackedArticles.Count,
+                    report.StaleArticles.Count,
+                    report.ReadingQueue.Count);
             }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)

--- a/tests/LoreAI.Core.Tests/Services/BrokenTrackedArticlesAnalyzerTests.cs
+++ b/tests/LoreAI.Core.Tests/Services/BrokenTrackedArticlesAnalyzerTests.cs
@@ -1,0 +1,49 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Core.Services;
+
+namespace LoreAI.Core.Tests.Services;
+
+public class BrokenTrackedArticlesAnalyzerTests
+{
+    [Fact]
+    public void Detect_BrokenLink_IsReported()
+    {
+        var articles = new[] { CreateArticle(1, LinkStatus.Broken) };
+
+        var result = BrokenTrackedArticlesAnalyzer.Detect(articles);
+
+        var single = Assert.Single(result);
+        Assert.Equal(LinkStatus.Broken, single.LinkStatus);
+    }
+
+    [Fact]
+    public void Detect_DeletedLink_IsReported()
+    {
+        var articles = new[] { CreateArticle(1, LinkStatus.Deleted) };
+
+        var result = BrokenTrackedArticlesAnalyzer.Detect(articles);
+
+        Assert.Single(result);
+    }
+
+    [Fact]
+    public void Detect_OkLink_IsIgnored()
+    {
+        var articles = new[] { CreateArticle(1, LinkStatus.Ok) };
+
+        Assert.Empty(BrokenTrackedArticlesAnalyzer.Detect(articles));
+    }
+
+    [Fact]
+    public void Detect_NeverReconciled_IsIgnored()
+    {
+        var articles = new[] { CreateArticle(1, linkStatus: null) };
+
+        Assert.Empty(BrokenTrackedArticlesAnalyzer.Detect(articles));
+    }
+
+    private static TrackedArticle CreateArticle(long id, LinkStatus? linkStatus) =>
+        new(id, $"Titre {id}", $"https://example.com/{id}", RecommendedAction.ALire, Priority.Basse,
+            DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch, null, null, linkStatus);
+}

--- a/tests/LoreAI.Core.Tests/Services/ReadingQueueScorerTests.cs
+++ b/tests/LoreAI.Core.Tests/Services/ReadingQueueScorerTests.cs
@@ -1,0 +1,75 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Core.Services;
+
+namespace LoreAI.Core.Tests.Services;
+
+public class ReadingQueueScorerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 25, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Score_HumanHandled_IsExcluded()
+    {
+        var articles = new[] { CreateArticle(1, Priority.Haute, humanHandledAtUtc: Now) };
+
+        Assert.Empty(ReadingQueueScorer.Score(articles, Now, 10));
+    }
+
+    [Fact]
+    public void Score_Deleted_IsExcluded()
+    {
+        var articles = new[] { CreateArticle(1, Priority.Haute, linkStatus: LinkStatus.Deleted) };
+
+        Assert.Empty(ReadingQueueScorer.Score(articles, Now, 10));
+    }
+
+    [Fact]
+    public void Score_HigherPriority_RanksFirst()
+    {
+        var articles = new[]
+        {
+            CreateArticle(1, Priority.Basse),
+            CreateArticle(2, Priority.Haute),
+        };
+
+        var result = ReadingQueueScorer.Score(articles, Now, 10);
+
+        Assert.Equal(2, result[0].Id);
+        Assert.Equal(1, result[1].Id);
+    }
+
+    [Fact]
+    public void Score_Fresher_RanksFirstAtEqualPriority()
+    {
+        var articles = new[]
+        {
+            CreateArticle(1, Priority.Moyenne, capturedAtUtc: Now.AddDays(-80)),
+            CreateArticle(2, Priority.Moyenne, capturedAtUtc: Now.AddDays(-1)),
+        };
+
+        var result = ReadingQueueScorer.Score(articles, Now, 10);
+
+        Assert.Equal(2, result[0].Id);
+        Assert.Equal(1, result[1].Id);
+    }
+
+    [Fact]
+    public void Score_RespectsLimit()
+    {
+        var articles = new[] { CreateArticle(1, Priority.Haute), CreateArticle(2, Priority.Haute), CreateArticle(3, Priority.Haute) };
+
+        var result = ReadingQueueScorer.Score(articles, Now, 2);
+
+        Assert.Equal(2, result.Count);
+    }
+
+    private static TrackedArticle CreateArticle(
+        long id,
+        Priority priority,
+        DateTimeOffset? capturedAtUtc = null,
+        DateTimeOffset? humanHandledAtUtc = null,
+        LinkStatus? linkStatus = null) =>
+        new(id, $"Titre {id}", $"https://example.com/{id}", RecommendedAction.ALire, priority,
+            capturedAtUtc ?? Now, Now, null, humanHandledAtUtc, linkStatus ?? LinkStatus.Ok);
+}

--- a/tests/LoreAI.Core.Tests/Services/StaleArticlesAnalyzerTests.cs
+++ b/tests/LoreAI.Core.Tests/Services/StaleArticlesAnalyzerTests.cs
@@ -1,0 +1,48 @@
+using LoreAI.Core.Enums;
+using LoreAI.Core.Models;
+using LoreAI.Core.Services;
+
+namespace LoreAI.Core.Tests.Services;
+
+public class StaleArticlesAnalyzerTests
+{
+    private static readonly DateTimeOffset Now = new(2026, 8, 25, 0, 0, 0, TimeSpan.Zero);
+
+    [Fact]
+    public void Detect_ALireOlderThan90Days_NeverHandled_IsReported()
+    {
+        var articles = new[] { CreateArticle(1, RecommendedAction.ALire, Now.AddDays(-91), humanHandledAtUtc: null) };
+
+        var result = StaleArticlesAnalyzer.Detect(articles, Now);
+
+        var single = Assert.Single(result);
+        Assert.Equal(91, single.DaysSinceCaptured);
+    }
+
+    [Fact]
+    public void Detect_ALireUnder90Days_IsIgnored()
+    {
+        var articles = new[] { CreateArticle(1, RecommendedAction.ALire, Now.AddDays(-10), humanHandledAtUtc: null) };
+
+        Assert.Empty(StaleArticlesAnalyzer.Detect(articles, Now));
+    }
+
+    [Fact]
+    public void Detect_AlreadyHumanHandled_IsIgnored()
+    {
+        var articles = new[] { CreateArticle(1, RecommendedAction.ALire, Now.AddDays(-91), humanHandledAtUtc: Now.AddDays(-1)) };
+
+        Assert.Empty(StaleArticlesAnalyzer.Detect(articles, Now));
+    }
+
+    [Fact]
+    public void Detect_NonALireAction_IsIgnored()
+    {
+        var articles = new[] { CreateArticle(1, RecommendedAction.ATester, Now.AddDays(-91), humanHandledAtUtc: null) };
+
+        Assert.Empty(StaleArticlesAnalyzer.Detect(articles, Now));
+    }
+
+    private static TrackedArticle CreateArticle(long id, RecommendedAction action, DateTimeOffset capturedAtUtc, DateTimeOffset? humanHandledAtUtc) =>
+        new(id, $"Titre {id}", $"https://example.com/{id}", action, Priority.Basse, capturedAtUtc, capturedAtUtc, null, humanHandledAtUtc, LinkStatus.Ok);
+}

--- a/tests/LoreAI.Infrastructure.Tests/Classification/ClassificationPromptBuilderTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Classification/ClassificationPromptBuilderTests.cs
@@ -93,10 +93,10 @@ public class ClassificationPromptBuilderTests
         var schema = ClassificationPromptBuilder.BuildToolInputSchemaJson(SampleTaxonomy);
 
         Assert.Contains("\"summary\"", schema);
-        Assert.Contains("\"required\":[\"suggestedCollection\",\"tags\",\"action\",\"priority\",\"reason\",\"summary\",\"toolName\",\"toolCategory\"]", schema);
+        Assert.Contains("\"required\":[\"suggestedCollection\",\"tags\",\"action\",\"priority\",\"reason\",\"summary\",\"toolName\",\"toolCategory\",\"toolUrl\"]", schema);
     }
 
-    /// <summary>S7 (lot 5) : les deux champs sont nullable, remplis par le modèle uniquement quand action=ATester.</summary>
+    /// <summary>S7 (lot 5) / S9 (lot 6) : les trois champs sont nullable, remplis par le modèle uniquement quand action=ATester.</summary>
     [Fact]
     public void BuildToolInputSchemaJson_IncludesNullableToolFields()
     {
@@ -104,6 +104,7 @@ public class ClassificationPromptBuilderTests
 
         Assert.Contains("\"toolName\"", schema);
         Assert.Contains("\"toolCategory\"", schema);
+        Assert.Contains("\"toolUrl\"", schema);
     }
 
     /// <summary>S1 (lot 4) : le contenu réel remplace l'excerpt dans le prompt quand il est disponible.</summary>

--- a/tests/LoreAI.Infrastructure.Tests/Classification/ClassificationResponseParserTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Classification/ClassificationResponseParserTests.cs
@@ -6,7 +6,7 @@ namespace LoreAI.Infrastructure.Tests.Classification;
 public class ClassificationResponseParserTests
 {
     private const string ValidJson = """
-        { "suggestedCollection": ".NET", "tags": ["dotnet", "outil"], "action": "ATester", "priority": "Haute", "reason": "Nouvel outil .NET intéressant.", "summary": "Un outil qui simplifie le déploiement .NET sur ARM.", "toolName": "Ollama", "toolCategory": "CLI" }
+        { "suggestedCollection": ".NET", "tags": ["dotnet", "outil"], "action": "ATester", "priority": "Haute", "reason": "Nouvel outil .NET intéressant.", "summary": "Un outil qui simplifie le déploiement .NET sur ARM.", "toolName": "Ollama", "toolCategory": "CLI", "toolUrl": "https://ollama.com" }
         """;
 
     [Fact]
@@ -22,6 +22,7 @@ public class ClassificationResponseParserTests
         Assert.Equal("Un outil qui simplifie le déploiement .NET sur ARM.", result.Summary);
         Assert.Equal("Ollama", result.ToolName);
         Assert.Equal("CLI", result.ToolCategory);
+        Assert.Equal("https://ollama.com", result.ToolUrl);
         Assert.Equal("claude-haiku-4-5", result.Model);
         Assert.Equal("raw", result.RawResponse);
     }
@@ -40,7 +41,7 @@ public class ClassificationResponseParserTests
         Assert.Equal(string.Empty, result.Summary);
     }
 
-    /// <summary>Comme `summary` : un fixture pré-lot-5 (sans `toolName`/`toolCategory`) doit continuer de parser.</summary>
+    /// <summary>Comme `summary` : un fixture pré-lot-5/lot-6 (sans `toolName`/`toolCategory`/`toolUrl`) doit continuer de parser.</summary>
     [Fact]
     public void Parse_MissingToolFields_DefaultToNull()
     {
@@ -50,17 +51,19 @@ public class ClassificationResponseParserTests
 
         Assert.Null(result.ToolName);
         Assert.Null(result.ToolCategory);
+        Assert.Null(result.ToolUrl);
     }
 
     [Fact]
     public void Parse_NullToolFields_ReturnNull()
     {
-        const string json = """{ "suggestedCollection": null, "tags": [], "action": "ALire", "priority": "Basse", "reason": "x", "toolName": null, "toolCategory": null }""";
+        const string json = """{ "suggestedCollection": null, "tags": [], "action": "ALire", "priority": "Basse", "reason": "x", "toolName": null, "toolCategory": null, "toolUrl": null }""";
 
         var result = ClassificationResponseParser.Parse(json, "model", "raw");
 
         Assert.Null(result.ToolName);
         Assert.Null(result.ToolCategory);
+        Assert.Null(result.ToolUrl);
     }
 
     [Fact]

--- a/tests/LoreAI.Infrastructure.Tests/Notifications/MarkdownReportBuilderTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Notifications/MarkdownReportBuilderTests.cs
@@ -158,5 +158,5 @@ public class MarkdownReportBuilderTests
         IReadOnlyList<DomainTrend> domains,
         IReadOnlyList<TagTrend> tags,
         LlmUsageSummary usage) =>
-        new(duplicates, hygiene, unbalanced, domains, tags, usage, DateTimeOffset.UnixEpoch);
+        new(duplicates, hygiene, unbalanced, domains, tags, usage, [], [], [], DateTimeOffset.UnixEpoch);
 }

--- a/tests/LoreAI.Infrastructure.Tests/Notifications/MarkdownReportBuilderTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Notifications/MarkdownReportBuilderTests.cs
@@ -129,6 +129,26 @@ public class MarkdownReportBuilderTests
     }
 
     [Fact]
+    public void BuildToolCard_WithUrl_IncludesUrlInFrontmatter()
+    {
+        var card = new ToolCard(1, "Ollama", "CLI", "À évaluer", null, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch, [], "https://ollama.com");
+
+        var markdown = MarkdownReportBuilder.BuildToolCard(card);
+
+        Assert.Contains("url: https://ollama.com", markdown);
+    }
+
+    [Fact]
+    public void BuildToolCard_NoUrl_OmitsUrlLine()
+    {
+        var card = new ToolCard(1, "Ollama", "CLI", "À évaluer", null, DateTimeOffset.UnixEpoch, DateTimeOffset.UnixEpoch, []);
+
+        var markdown = MarkdownReportBuilder.BuildToolCard(card);
+
+        Assert.DoesNotContain("url:", markdown);
+    }
+
+    [Fact]
     public void BuildItemExport_ClassifiedItem_IncludesSummary()
     {
         var item = new LibraryItemSummary(1, "Titre", "https://a.example", ["dotnet"], 10, new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero));

--- a/tests/LoreAI.Infrastructure.Tests/Persistence/ArticleRepositoryTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Persistence/ArticleRepositoryTests.cs
@@ -60,7 +60,7 @@ public class ArticleRepositoryTests : IAsyncLifetime
     {
         await _repository.UpsertAsync(CreateItem(1, "A"), CreateClassification(), ContentFetchResult.Skipped, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
-        await _repository.RecordWriteBackAsync(1, success: true, moved: true, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.RecordWriteBackAsync(1, success: true, moved: true, writeBackCollectionId: 42, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         var entity = await GetAsync(1);
         Assert.True(entity.Moved);
@@ -71,7 +71,7 @@ public class ArticleRepositoryTests : IAsyncLifetime
     {
         await _repository.UpsertAsync(CreateItem(1, "A"), CreateClassification(), ContentFetchResult.Skipped, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
-        await _repository.RecordWriteBackAsync(1, success: true, moved: false, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.RecordWriteBackAsync(1, success: true, moved: false, writeBackCollectionId: null, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         var entity = await GetAsync(1);
         Assert.False(entity.Moved);

--- a/tests/LoreAI.Infrastructure.Tests/Persistence/ToolRepositoryTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Persistence/ToolRepositoryTests.cs
@@ -28,7 +28,7 @@ public class ToolRepositoryTests : IAsyncLifetime
     {
         var seenAt = DateTimeOffset.UtcNow;
 
-        await _repository.UpsertFromArticleAsync("Ollama", "CLI", 1, seenAt, TestContext.Current.CancellationToken);
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", null, 1, seenAt, TestContext.Current.CancellationToken);
 
         await using var context = _fixture.CreateContext();
         var tool = await context.Tools.SingleAsync(TestContext.Current.CancellationToken);
@@ -40,11 +40,33 @@ public class ToolRepositoryTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task UpsertFromArticleAsync_NewTool_PersistsUrl()
+    {
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", "https://ollama.com", 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+
+        await using var context = _fixture.CreateContext();
+        var tool = await context.Tools.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("https://ollama.com", tool.Url);
+    }
+
+    [Fact]
+    public async Task UpsertFromArticleAsync_ExistingTool_NeverOverwritesUrl()
+    {
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", "https://ollama.com", 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", "https://autre-lien.example", 2, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+
+        await using var context = _fixture.CreateContext();
+        var tool = await context.Tools.SingleAsync(TestContext.Current.CancellationToken);
+        Assert.Equal("https://ollama.com", tool.Url);
+    }
+
+    [Fact]
     public async Task UpsertFromArticleAsync_ExistingToolCaseInsensitiveMatch_AddsRelatedArticleWithoutDuplicating()
     {
-        await _repository.UpsertFromArticleAsync("Ollama", "CLI", 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", null, 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
-        await _repository.UpsertFromArticleAsync("ollama", "CLI", 2, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.UpsertFromArticleAsync("ollama", "CLI", null, 2, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         await using var context = _fixture.CreateContext();
         var tool = await context.Tools.SingleAsync(TestContext.Current.CancellationToken);
@@ -54,9 +76,9 @@ public class ToolRepositoryTests : IAsyncLifetime
     [Fact]
     public async Task UpsertFromArticleAsync_SameArticleTwice_DoesNotDuplicateId()
     {
-        await _repository.UpsertFromArticleAsync("Ollama", "CLI", 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", null, 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
-        await _repository.UpsertFromArticleAsync("Ollama", "CLI", 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", null, 1, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
 
         await using var context = _fixture.CreateContext();
         var tool = await context.Tools.SingleAsync(TestContext.Current.CancellationToken);
@@ -82,7 +104,7 @@ public class ToolRepositoryTests : IAsyncLifetime
         }
 
         var newSeenAt = DateTimeOffset.UtcNow;
-        await _repository.UpsertFromArticleAsync("Ollama", "CLI", 2, newSeenAt, TestContext.Current.CancellationToken);
+        await _repository.UpsertFromArticleAsync("Ollama", "CLI", null, 2, newSeenAt, TestContext.Current.CancellationToken);
 
         await using var readContext = _fixture.CreateContext();
         var tool = await readContext.Tools.SingleAsync(TestContext.Current.CancellationToken);

--- a/tests/LoreAI.Mcp.Tests/Tools/CorpusToolsTests.cs
+++ b/tests/LoreAI.Mcp.Tests/Tools/CorpusToolsTests.cs
@@ -160,11 +160,24 @@ public class CorpusToolsTests
     }
 
     [Fact]
-    public void ListTools_ReadingQueue_IsMarkedNotImplemented()
+    public void ListTools_ReadingQueue_IsMarkedImplemented()
     {
         var tools = _tools.ListTools();
 
-        Assert.Contains(tools, t => t.Name == "reading_queue" && t.Status.StartsWith("non implémenté", StringComparison.Ordinal));
+        Assert.Contains(tools, t => t.Name == "reading_queue" && t.Status.StartsWith("implémenté", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData(0, 20)]
+    [InlineData(-1, 20)]
+    [InlineData(500, 100)]
+    public async Task ReadingQueue_ClampsCountToValidRange(int requested, int expected)
+    {
+        _repository.GetReadingQueueAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
+
+        await _tools.ReadingQueue(requested, TestContext.Current.CancellationToken);
+
+        await _repository.Received(1).GetReadingQueueAsync(expected, Arg.Any<CancellationToken>());
     }
 
     [Fact]

--- a/tests/LoreAI.Worker.Tests/Services/ReconciliationJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/ReconciliationJobTests.cs
@@ -1,0 +1,205 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+using LoreAI.Worker.Services;
+
+namespace LoreAI.Worker.Tests.Services;
+
+/// <summary>Couvre L3 (réconciliation) et L4 (relance), greffée dans la même passe — lot 6, #47.</summary>
+public class ReconciliationJobTests
+{
+    private static readonly DateTimeOffset Now = DateTimeOffset.UtcNow;
+
+    [Fact]
+    public async Task Invoke_ItemDeletedFromRaindrop_RecordsDeletedLinkStatus()
+    {
+        var fixture = new JobFixture().WithCandidates(CreateCandidate(1));
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>()).Returns((RaindropSnapshot?)null);
+
+        await fixture.Build().Invoke();
+
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), null, null, LinkStatus.Deleted, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_ItemMarkedBrokenByRaindrop_RecordsBrokenLinkStatus()
+    {
+        var fixture = new JobFixture().WithCandidates(CreateCandidate(1));
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, ["dotnet"], Broken: true));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), LinkStatus.Broken, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_TagsDivergeFromWhatWasWritten_MarksHumanHandled()
+    {
+        var candidate = CreateCandidate(1, originalTags: ["dotnet"], suggestedTags: ["ia"]);
+        var fixture = new JobFixture().WithCandidates(candidate);
+        // L'utilisateur a retiré "ia" et ajouté "perso" : divergence par rapport à dotnet+ia écrit par LoreAI.
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, ["dotnet", "perso"], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), Arg.Is<DateTimeOffset?>(d => d != null), Arg.Any<DateTimeOffset?>(), LinkStatus.Ok, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_CollectionDivergesFromWriteBack_MarksHumanHandled()
+    {
+        var candidate = CreateCandidate(1, writeBackCollectionId: 10);
+        var fixture = new JobFixture().WithCandidates(candidate);
+        // L'article a été déplacé manuellement vers une autre collection que celle écrite par LoreAI.
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, 99, candidate.OriginalTags.Concat(candidate.SuggestedTags).ToList(), Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), Arg.Is<DateTimeOffset?>(d => d != null), Arg.Any<DateTimeOffset?>(), LinkStatus.Ok, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_NothingChanged_LeavesHumanHandledNull()
+    {
+        var candidate = CreateCandidate(1, originalTags: ["dotnet"], suggestedTags: [], writeBackCollectionId: null);
+        var fixture = new JobFixture().WithCandidates(candidate);
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, ["dotnet"], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), null, null, LinkStatus.Ok, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_AlreadyHumanHandled_NeverReEvaluatesDivergence()
+    {
+        var candidate = CreateCandidate(1, humanHandledAtUtc: Now.AddDays(-5));
+        var fixture = new JobFixture().WithCandidates(candidate);
+        // Peu importe ce qui a encore changé depuis : HumanHandledAtUtc ne doit jamais être ré-évalué une fois posé.
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, 12345, ["autre-chose"], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), candidate.HumanHandledAtUtc, Arg.Any<DateTimeOffset?>(), LinkStatus.Ok, Arg.Any<CancellationToken>());
+    }
+
+    // --- L4 : relance -----------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Invoke_ATesterHauteUnhandledPast14Days_SendsReminderOnce()
+    {
+        var candidate = CreateCandidate(1, action: RecommendedAction.ATester, priority: Priority.Haute, classifiedAtUtc: Now.AddDays(-15));
+        var fixture = new JobFixture().WithCandidates(candidate);
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, [], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ReminderNotifier.Received(1).NotifyAsync(candidate.Title, candidate.Url, Arg.Any<int>(), Arg.Any<CancellationToken>());
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset?>(), Arg.Is<DateTimeOffset?>(d => d != null), Arg.Any<LinkStatus>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_AlreadyReminded_NeverSendsTwice()
+    {
+        var candidate = CreateCandidate(1, action: RecommendedAction.ATester, priority: Priority.Haute, classifiedAtUtc: Now.AddDays(-30), remindedAtUtc: Now.AddDays(-16));
+        var fixture = new JobFixture().WithCandidates(candidate);
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, [], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ReminderNotifier.DidNotReceive().NotifyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_ATesterHauteUnder14Days_DoesNotRemindYet()
+    {
+        var candidate = CreateCandidate(1, action: RecommendedAction.ATester, priority: Priority.Haute, classifiedAtUtc: Now.AddDays(-3));
+        var fixture = new JobFixture().WithCandidates(candidate);
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, [], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ReminderNotifier.DidNotReceive().NotifyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_LowerPriorityUnhandled_NeverReminds()
+    {
+        var candidate = CreateCandidate(1, action: RecommendedAction.ATester, priority: Priority.Basse, classifiedAtUtc: Now.AddDays(-30));
+        var fixture = new JobFixture().WithCandidates(candidate);
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, [], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.ReminderNotifier.DidNotReceive().NotifyAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_FailureOnOneArticle_StillProcessesTheRest()
+    {
+        var fixture = new JobFixture().WithCandidates(CreateCandidate(1), CreateCandidate(2));
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>()).ThrowsAsync(new HttpRequestException("502"));
+        fixture.RaindropClient.GetRaindropAsync(2, Arg.Any<CancellationToken>()).Returns(new RaindropSnapshot(2, -1, [], Broken: false));
+
+        var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());
+
+        Assert.Null(exception);
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            2, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<LinkStatus>(), Arg.Any<CancellationToken>());
+        await fixture.ArticleRepository.DidNotReceive().RecordReconciliationAsync(
+            1, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<LinkStatus>(), Arg.Any<CancellationToken>());
+    }
+
+    private static ReconciliationCandidate CreateCandidate(
+        long id,
+        IReadOnlyList<string>? originalTags = null,
+        IReadOnlyList<string>? suggestedTags = null,
+        long? writeBackCollectionId = null,
+        RecommendedAction action = RecommendedAction.ALire,
+        Priority priority = Priority.Basse,
+        DateTimeOffset? classifiedAtUtc = null,
+        DateTimeOffset? humanHandledAtUtc = null,
+        DateTimeOffset? remindedAtUtc = null) =>
+        new(id, $"Titre {id}", $"https://example.com/{id}",
+            originalTags ?? [], suggestedTags ?? [], writeBackCollectionId,
+            action, priority, classifiedAtUtc ?? Now.AddDays(-1), humanHandledAtUtc, remindedAtUtc);
+
+    private sealed class JobFixture
+    {
+        public IRaindropClient RaindropClient { get; } = Substitute.For<IRaindropClient>();
+        public IArticleRepository ArticleRepository { get; } = Substitute.For<IArticleRepository>();
+        public IReminderNotifier ReminderNotifier { get; } = Substitute.For<IReminderNotifier>();
+
+        public JobFixture()
+        {
+            ArticleRepository.GetReconciliationCandidatesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns([]);
+        }
+
+        public JobFixture WithCandidates(params ReconciliationCandidate[] candidates)
+        {
+            ArticleRepository.GetReconciliationCandidatesAsync(Arg.Any<int>(), Arg.Any<CancellationToken>()).Returns(candidates);
+            return this;
+        }
+
+        public ReconciliationJob Build() => new(RaindropClient, ArticleRepository, ReminderNotifier, NullLogger<ReconciliationJob>.Instance);
+    }
+}

--- a/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
@@ -601,7 +601,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         await fixture.ToolRepository.Received(1).UpsertFromArticleAsync(
-            "Ollama", "CLI", 1, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+            "Ollama", "CLI", null, 1, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -614,7 +614,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         await fixture.ToolRepository.DidNotReceive().UpsertFromArticleAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -627,7 +627,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         await fixture.ToolRepository.DidNotReceive().UpsertFromArticleAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -640,7 +640,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         await fixture.ToolRepository.DidNotReceive().UpsertFromArticleAsync(
-            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+            Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
     }
 
     /// <summary>Best-effort (S7) : un échec de la base d'outils ne doit jamais bloquer le cycle.</summary>
@@ -651,7 +651,7 @@ public class UnsortedClassificationJobTests
             .WithNewItems(CreateItem(1))
             .WithClassification(CreateClassification(".NET", ["dotnet"]) with { ToolName = "Ollama" });
         fixture.ToolRepository
-            .UpsertFromArticleAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .UpsertFromArticleAsync(Arg.Any<string>(), Arg.Any<string?>(), Arg.Any<string?>(), Arg.Any<long>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new InvalidOperationException("database is locked"));
 
         var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());

--- a/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/UnsortedClassificationJobTests.cs
@@ -255,7 +255,7 @@ public class UnsortedClassificationJobTests
         await fixture.Build().Invoke();
 
         // L'échec de write-back est déjà rattrapé et enregistré ; il ne doit pas bloquer le batch.
-        await fixture.ArticleRepository.Received(1).RecordWriteBackAsync(1, false, false, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+        await fixture.ArticleRepository.Received(1).RecordWriteBackAsync(1, false, false, null, Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
         await fixture.PollingStateRepository.Received(1).UpdateAsync(
             Arg.Is<PollingState>(s => s!.LastSourceItemId == "2"), Arg.Any<CancellationToken>());
     }

--- a/tests/LoreAI.Worker.Tests/Services/WeeklyInsightsJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/WeeklyInsightsJobTests.cs
@@ -84,6 +84,7 @@ public class WeeklyInsightsJobTests
             LibraryItemRepository.GetAllForInsightsAsync(Arg.Any<CancellationToken>()).Returns([]);
             RaindropClient.GetTaxonomyAsync(Arg.Any<CancellationToken>()).Returns(EmptyTaxonomy);
             ArticleRepository.GetClassificationRawResponsesSinceAsync(Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>()).Returns([]);
+            ArticleRepository.GetTrackedArticlesAsync(Arg.Any<CancellationToken>()).Returns([]);
         }
 
         public JobFixture WithTaxonomy(RaindropTaxonomy taxonomy)


### PR DESCRIPTION
## Résumé

Implémente le lot 6 — « Boucle de retour » ([#47](https://github.com/slucky31/LoreAI/issues/47)) :

- **L3** `ReconciliationJob` (nouveau job quotidien, 2h UTC) : re-fetch des articles suivis pour détecter tags/collection modifiés par l'utilisateur (`HumanHandledAtUtc`, signal « lu »), articles supprimés ou liens cassés (`LinkStatus`).
- **L4** Relance Discord greffée dans la même passe : `ATester`/`Haute` non traité 14 jours après classification, une seule fois (`RemindedAtUtc`).
- **N3** Liens morts/supprimés parmi les articles suivis — nouvelle section du rapport hebdomadaire.
- **N4** Articles « À lire » périmés (90 jours sans traitement) — proposition de purge, jamais automatique.
- **L1** File de lecture scorée (priorité × fraîcheur × temps de lecture), intégrée au rapport hebdomadaire et exposée à la demande via l'outil MCP `reading_queue` (remplace son stub « non implémenté »).
- **O4** ([#71](https://github.com/slucky31/LoreAI/issues/71)) `TZ=Europe/Paris` sur les deux Dockerfiles (Worker + MCP) — seul l'horodatage Serilog change, aucune valeur UTC de domaine.
- **O5** ([#75](https://github.com/slucky31/LoreAI/issues/75)) `--run-weekly-insights`/`--run-monthly-review`, même patron que `--health-check`.
- **S9** ([#73](https://github.com/slucky31/LoreAI/issues/73)) `toolUrl` de bout en bout (prompt → schéma → parseur → entité → dépôt → fiche MCP `tool_card`).

**Hors scope, volontairement** : L5 (collection pilote « À lire cette semaine ») — implique une écriture hors « Non trié », exige une validation explicite avant d'être attaqué (cf. roadmap).

Deux migrations EF Core : `AddReconciliationFields`, `AddToolUrl`.

## Test plan

- [x] `dotnet build LoreAI.slnx` sans erreur ni avertissement
- [x] `dotnet test LoreAI.slnx` — 318/318 tests passent (Docker actif, `Infrastructure.Tests` compris)
- [ ] O4 non vérifié par un build Docker réel de l'image chiselée finale (`docker build`) — à confirmer au premier déploiement sur `mcm8`
- [ ] Vérification en production après déploiement : `ReconciliationJob` (cron quotidien), relance L4, nouvelles sections N3/N4/L1 du rapport hebdomadaire, `reading_queue` via MCP, `tool_card` avec `url:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YD9QVSMUUkykAme7rp9Bqa