### PR TITLE
docs: planifie le lot 7 (O6, #78) et replanifie L5 vers le lot 8

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -341,7 +341,6 @@ networks:
 - **L3** `ReconciliationJob` : re-fetch des items Raindrop suivis, détection des tags et collections modifiés, des articles supprimés, du flag `broken`. Colonnes `LastSeenAtUtc`, `HumanHandledAtUtc`, `LinkStatus`.
 - **L4** relances, **N3** liens morts, **N4** péremption : tous triviaux une fois L3 en place.
 - **L1** file de lecture, enfin scorée sur des données complètes (priorité × fraîcheur × temps de lecture × non-traité). C'est ici que le filet perdu au lot 2 est remplacé par quelque chose de mieux.
-- **L5** collection pilote « À lire cette semaine », **seulement après validation explicite** de l'écriture hors « Non trié ».
 - **O4** logs en heure de Paris ([#71](https://github.com/slucky31/LoreAI/issues/71)) — sans rapport avec le reste du lot, embarqué ici parce que ce lot touche de toute façon `Program.cs`/`Dockerfile`.
 - **S9** lien projet dans la base d'outils ([#73](https://github.com/slucky31/LoreAI/issues/73)) — sans rapport avec le reste du lot ni dépendance technique avec lui ; simplement le prochain lot ouvert, plus économique qu'une PR dédiée pour un seul champ.
 - **O5** déclenchement manuel de `WeeklyInsightsJob`/`MonthlyReviewJob` ([#75](https://github.com/slucky31/LoreAI/issues/75)) — mode CLI `--run-weekly-insights`/`--run-monthly-review`, même patron que `--health-check`. Sans rapport avec le reste du lot, embarqué ici pour la même raison qu'O4/S9.
@@ -363,6 +362,8 @@ Remplace Feedly sans rien auto-héberger de plus (voir l'arbitrage Miniflux).
 `GmailIngester` : OAuth Google en scope `gmail.readonly`, `users.messages.list` filtré sur `q=label:<tag>`, extraction du corps HTML avec le même extracteur que S1, curseur sur `historyId`.
 
 ⚠️ Deux points de vigilance : le refresh token doit être stocké (jamais en clair dans le dépôt, cf. `.env`), et une newsletter contient typiquement **plusieurs liens** — il faut décider si l'unité est le mail ou chaque lien qu'il contient. Recommandation : le mail comme `Item`, les liens extraits comme items secondaires rattachés, sinon le corpus explose en bruit.
+
+- **L5** collection pilote « À lire cette semaine », alimentée par L1 ([#47](https://github.com/slucky31/LoreAI/issues/47)) — exclue du lot 6 faute de validation explicite de l'écriture hors « Non trié » ; replanifiée ici comme prochain lot ouvert, même raison qu'O4/S9/O5/O6. **Toujours conditionnée à cette validation avant implémentation.**
 
 #### Lot 9 — Veille automatique (**C4**)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -148,6 +148,7 @@ Ce que ça coûte, et qu'il faut regarder en face :
 | O3 | **Cache de prompt Anthropic** ([#34](https://github.com/slucky31/LoreAI/issues/34)) | 1 | 2 | **Sans effet au régime actuel** — voir l'arbitrage dédié. C'est une optimisation de *backfill*, pas de croisière. À mesurer (30 min) avant de planifier |
 | O4 | **Logs en heure de Paris plutôt qu'UTC** ([#71](https://github.com/slucky31/LoreAI/issues/71)) | 1 | 1 | `TZ=Europe/Paris` sur les deux conteneurs — mais les images finales sont chiselées et tournent en `GLOBALIZATION_INVARIANT`, sans `tzdata` : à résoudre en copiant `/usr/share/zoneinfo` depuis l'étage `build` (qui a `apt`), comme `/data-skeleton`. Seul l'horodatage Serilog change, jamais les valeurs UTC de domaine (Postgres, noms de fichiers de rapport). **Planifié pour le lot 6**, embarqué dans la même PR plutôt qu'en PR dédiée |
 | O5 | **Déclenchement manuel de `WeeklyInsightsJob`/`MonthlyReviewJob`** ([#75](https://github.com/slucky31/LoreAI/issues/75)) | 2 | 1 | Deux jobs à cadence lente (hebdo/mensuelle) sans aucun moyen de forcer un passage — vérifier en prod a coûté plusieurs jours d'attente au lot 5. Mode CLI `--run-weekly-insights`/`--run-monthly-review`, même patron que `--health-check` (`HealthCheckMode.cs`) : pas de nouvel état à persister, contrairement à un flag « on startup » qui rejouerait le rapport à chaque redémarrage. **Planifié pour le lot 6** |
+| O6 | **Rapport hebdomadaire : digest Discord mobile-friendly** ([#78](https://github.com/slucky31/LoreAI/issues/78)) | 2 | 2 | Constaté à la vérification en prod du lot 6 : le fichier `.md` en pièce jointe est peu pratique sur mobile, et une section à fort volume (34 articles périmés) décourage plus qu'elle n'encourage. Remplacé par un digest Discord natif (embeds), top 10 + total par section, réparti en deux messages (actionnable / hygiène) pour rester sous la limite Discord de 6000 caractères. `MonthlyReviewJob` non concerné (format narratif conservé). **Planifié pour le lot 7** |
 
 ## Le worker n'a aucune mémoire de son dernier cycle
 
@@ -354,6 +355,8 @@ Ne commence qu'une fois le lot 4 livré : les deux connecteurs ont besoin de l'e
 `FeedIngester` implémentant `ISourceIngester` : liste de flux en configuration ou en base, parsing via `System.ServiceModel.Syndication`, curseur par flux sur la date de publication. Les entrées deviennent des `Item` avec `SourceType = Feed` et passent dans le pipeline de classification existant.
 
 Remplace Feedly sans rien auto-héberger de plus (voir l'arbitrage Miniflux).
+
+- **O6** rapport hebdomadaire mobile-friendly ([#78](https://github.com/slucky31/LoreAI/issues/78)) — sans rapport avec le connecteur RSS, embarqué ici parce que c'est le prochain lot ouvert, même raison qu'O4/S9/O5 au lot 6.
 
 #### Lot 8 — Connecteur newsletters Gmail (**C2**)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -359,7 +359,9 @@ Remplace Feedly sans rien auto-héberger de plus (voir l'arbitrage Miniflux).
 
 #### Lot 8 — Connecteur newsletters Gmail (**C2**)
 
-`GmailIngester` : OAuth Google en scope `gmail.readonly`, `users.messages.list` filtré sur `q=label:<tag>`, extraction du corps HTML avec le même extracteur que S1, curseur sur `historyId` (bookkeeping interne à l'ingester, jamais persisté comme `Item` — pas d'`Item` pour le mail lui-même).
+`GmailIngester` : OAuth Google en scope `gmail.readonly`, `users.messages.list` filtré sur `q=label:<tag>`, curseur sur `historyId` (bookkeeping interne à l'ingester, jamais persisté comme `Item` — pas d'`Item` pour le mail lui-même).
+
+**Corps du mail : privilégier la partie `text/plain`**, pas de parsing DOM. Sur 5 newsletters réelles (Kit, ConvertKit, EmailOctopus...), le fallback `text/plain` du `multipart/alternative` est déjà du texte lisible, en ordre de lecture, avec les URLs inlinées (`texte ( https://... )`) — nettement plus robuste qu'analyser le DOM HTML de templates chacun différents. Fallback HTML→texte brut (strip tags, décode entités) seulement si un mail est HTML-only sans partie texte ; pas besoin d'un extracteur readability comme S1, la fidélité de mise en page n'a pas à être parfaite ici.
 
 ⚠️ **Secrets** : le refresh token doit être stocké hors du dépôt (`.env`/`user-secrets`, jamais en clair).
 
@@ -367,8 +369,8 @@ Remplace Feedly sans rien auto-héberger de plus (voir l'arbitrage Miniflux).
 
 **Tri contenu vs bruit — décidé sur échantillons réels (2026-08-26)** : une newsletter mono-article (Milan Jovanovic, Anton DevTips) noie 1 vrai article dans ~15 liens de sponsors/auto-promo/réseaux sociaux/désinscription ; une newsletter perso (Kit) répète le même lien de tracking sous plusieurs ancres ; un vrai digest (Programmez) contient ~12 articles distincts légitimes — **et le lien éditorial comme le lien de nav partagent le même domaine de tracking**, donc aucun filtre par domaine ne peut les distinguer seul. Pipeline à deux étages :
 
-1. **Filtre heuristique** (gratuit, dans `GmailIngester`) : dédup des hrefs strictement identiques, exclusion des patterns triviaux (`unsubscribe`, `preferences`, profils réseaux sociaux type `linkedin.com/in/`/`youtube.com/@` — en gardant `youtube.com/watch` qui peut être le contenu).
-2. **Extraction LLM** (nouveau composant `IEmailLinkExtractor`, symétrique à `IClassifier` mais en amont — tool-use forcé comme `AnthropicClassifier`) : sur les liens restants + leur contexte textuel, tranche lesquels sont de vrais articles (0 à N par mail, gère aussi bien le cas mono-article que le digest).
+1. **Filtre heuristique** (gratuit, dans `GmailIngester`) : dédup des hrefs strictement identiques, exclusion des patterns triviaux (`unsubscribe`, `preferences`, profils réseaux sociaux type `linkedin.com/in/`/`youtube.com/@` — en gardant `youtube.com/watch` qui peut être le contenu). Aucune URL trouvée après ce filtre → court-circuit, 0 item, pas d'appel LLM.
+2. **Extraction LLM** (nouveau composant `IEmailLinkExtractor`, symétrique à `IClassifier` mais en amont — tool-use forcé comme `AnthropicClassifier`) : **pas de fenêtrage par lien** — le corps entier du mail (quelques Ko, largement dans le budget de contexte de Haiku) est donné en une fois, le LLM tranche lesquelles des URLs restantes sont de vrais articles (0 à N par mail, gère aussi bien le cas mono-article que le digest) et propose au passage le titre de l'article (`Item.Title`) à partir du contexte, sans fetch séparé. Une liste vide en retour est un résultat légitime, même philosophie que `ClassificationResult.Fallback` : jamais une erreur, le curseur `historyId` avance quand même.
 
 ⚠️ **Coût** : ajoute un **second type d'appel LLM** au pipeline Gmail (extraction par mail, en plus de la classification par item déjà existante) — à faire remonter dans `LlmUsageAnalyzer` (S6) comme le reste.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -359,9 +359,18 @@ Remplace Feedly sans rien auto-héberger de plus (voir l'arbitrage Miniflux).
 
 #### Lot 8 — Connecteur newsletters Gmail (**C2**)
 
-`GmailIngester` : OAuth Google en scope `gmail.readonly`, `users.messages.list` filtré sur `q=label:<tag>`, extraction du corps HTML avec le même extracteur que S1, curseur sur `historyId`.
+`GmailIngester` : OAuth Google en scope `gmail.readonly`, `users.messages.list` filtré sur `q=label:<tag>`, extraction du corps HTML avec le même extracteur que S1, curseur sur `historyId` (bookkeeping interne à l'ingester, jamais persisté comme `Item` — pas d'`Item` pour le mail lui-même).
 
-⚠️ Deux points de vigilance : le refresh token doit être stocké (jamais en clair dans le dépôt, cf. `.env`), et une newsletter contient typiquement **plusieurs liens** — il faut décider si l'unité est le mail ou chaque lien qu'il contient. Recommandation : le mail comme `Item`, les liens extraits comme items secondaires rattachés, sinon le corpus explose en bruit.
+⚠️ **Secrets** : le refresh token doit être stocké hors du dépôt (`.env`/`user-secrets`, jamais en clair).
+
+**Unité = le lien, jamais le mail.** Le modèle `Item` (ADR 0012) est plat, sans notion de parent/enfant, et les sources Feed/Newsletter ne sont jamais écrites en retour (ADR 0012) : la granularité n'a d'impact que sur L1/recherche MCP/dédup lot 10, qui ont tous besoin d'une clé par URL. Un `Item` par lien retenu, `SourceType = Email`, zéro changement de schéma.
+
+**Tri contenu vs bruit — décidé sur échantillons réels (2026-08-26)** : une newsletter mono-article (Milan Jovanovic, Anton DevTips) noie 1 vrai article dans ~15 liens de sponsors/auto-promo/réseaux sociaux/désinscription ; une newsletter perso (Kit) répète le même lien de tracking sous plusieurs ancres ; un vrai digest (Programmez) contient ~12 articles distincts légitimes — **et le lien éditorial comme le lien de nav partagent le même domaine de tracking**, donc aucun filtre par domaine ne peut les distinguer seul. Pipeline à deux étages :
+
+1. **Filtre heuristique** (gratuit, dans `GmailIngester`) : dédup des hrefs strictement identiques, exclusion des patterns triviaux (`unsubscribe`, `preferences`, profils réseaux sociaux type `linkedin.com/in/`/`youtube.com/@` — en gardant `youtube.com/watch` qui peut être le contenu).
+2. **Extraction LLM** (nouveau composant `IEmailLinkExtractor`, symétrique à `IClassifier` mais en amont — tool-use forcé comme `AnthropicClassifier`) : sur les liens restants + leur contexte textuel, tranche lesquels sont de vrais articles (0 à N par mail, gère aussi bien le cas mono-article que le digest).
+
+⚠️ **Coût** : ajoute un **second type d'appel LLM** au pipeline Gmail (extraction par mail, en plus de la classification par item déjà existante) — à faire remonter dans `LlmUsageAnalyzer` (S6) comme le reste.
 
 - **L5** collection pilote « À lire cette semaine », alimentée par L1 ([#47](https://github.com/slucky31/LoreAI/issues/47)) — exclue du lot 6 faute de validation explicite de l'écriture hors « Non trié » ; replanifiée ici comme prochain lot ouvert, même raison qu'O4/S9/O5/O6. **Toujours conditionnée à cette validation avant implémentation.**
 


### PR DESCRIPTION
## Summary
- Planifie le digest hebdo mobile-friendly (O6, #78) sur le lot 7 (`docs/roadmap.md`, `docs/etat-des-lieux.md`)
- Replanifie L5 (collection pilote « À lire cette semaine ») du lot 6 vers le lot 8 : exclue du lot 6 faute de validation explicite de l'écriture hors « Non trié », déplacée comme prochain lot ouvert (#47, #49)

## Test plan
- [x] Documentation uniquement, aucun changement de code — pas de suite de tests à lancer