### PR TITLE
fix: référence les liens de newsletter par index plutôt que par URL recopiée

### DIFF
--- a/src/LoreAI.Infrastructure/Classification/EmailLinkExtractionPromptBuilder.cs
+++ b/src/LoreAI.Infrastructure/Classification/EmailLinkExtractionPromptBuilder.cs
@@ -12,15 +12,16 @@ public static class EmailLinkExtractionPromptBuilder
 
     public const string SystemPrompt = """
         Tu aides un développeur .NET à trier les liens d'une newsletter qu'il reçoit par mail, déjà réduite à
-        une liste d'URLs candidates (le bruit évident — désinscription, réseaux sociaux, tracking répété — a
-        déjà été retiré en amont).
+        une liste d'URLs candidates numérotées (le bruit évident — désinscription, réseaux sociaux, tracking
+        répété — a déjà été retiré en amont).
         À partir du sujet et du corps du mail, détermine lesquelles de ces URLs candidates pointent vers un
         vrai article/outil/annonce à conserver (0 à N, aussi bien pour une newsletter mono-article que pour
         un digest de plusieurs articles), et propose pour chacune un titre court à partir du contexte du mail
         — jamais en devinant, uniquement ce qui est déductible du texte fourni.
         Règles strictes :
-        - N'utilise que des URLs qui apparaissent mot pour mot dans la liste candidate fournie. N'en invente
-          jamais et ne modifie jamais une URL candidate.
+        - Désigne chaque URL retenue par son index dans la liste numérotée fournie, jamais en recopiant
+          l'URL elle-même (certaines URLs de tracking sont très longues — l'index suffit et évite toute
+          erreur de recopie).
         - Exclut les liens de simple navigation (sommaire, "lire en ligne", pied de page) qui auraient
           survécu au filtre en amont, s'ils ne pointent pas vers un contenu en propre.
         - Une liste vide est un résultat parfaitement valide si aucune URL candidate ne correspond à un vrai
@@ -48,10 +49,10 @@ public static class EmailLinkExtractionPromptBuilder
                         type = "object",
                         properties = new
                         {
-                            url = new { type = "string", maxLength = 2000, description = "Doit être identique à une des URLs candidates fournies." },
+                            index = new { type = "integer", minimum = 0, description = "Index (0-based) de l'URL retenue dans la liste numérotée fournie." },
                             title = new { type = "string", maxLength = 200 },
                         },
-                        required = new[] { "url", "title" },
+                        required = new[] { "index", "title" },
                     },
                 },
             },
@@ -64,7 +65,7 @@ public static class EmailLinkExtractionPromptBuilder
     public static string BuildUserMessage(string subject, string body, IReadOnlyList<string> candidateUrls)
     {
         var urlsList = candidateUrls.Count > 0
-            ? string.Join('\n', candidateUrls.Select(u => $"- {u}"))
+            ? string.Join('\n', candidateUrls.Select((u, i) => $"[{i}] {u}"))
             : "(aucune)";
 
         return $"""
@@ -74,7 +75,7 @@ public static class EmailLinkExtractionPromptBuilder
             {Truncate(body, MaxBodyLength)}
             </mail>
 
-            URLs candidates (filtre heuristique déjà appliqué) :
+            URLs candidates (filtre heuristique déjà appliqué) — désigne-les par leur index [n], jamais en recopiant l'URL :
             {urlsList}
             """;
     }

--- a/src/LoreAI.Infrastructure/Classification/EmailLinkExtractionResponseParser.cs
+++ b/src/LoreAI.Infrastructure/Classification/EmailLinkExtractionResponseParser.cs
@@ -6,9 +6,10 @@ namespace LoreAI.Infrastructure.Classification;
 
 /// <summary>
 /// Valide défensivement la sortie de l'extraction de liens (lot 8, #49), même patron que
-/// <see cref="ClassificationResponseParser"/>. Garde supplémentaire propre à ce parseur : une URL renvoyée
-/// par le modèle qui ne figure pas mot pour mot dans les URLs candidates fournies est rejetée — le modèle
-/// ne doit jamais pouvoir faire écrire une URL inventée ou légèrement modifiée.
+/// <see cref="ClassificationResponseParser"/>. Le modèle désigne un lien par son index dans la liste
+/// candidate (jamais en recopiant l'URL — évite de faire porter au budget de tokens le coût de recopier des
+/// URLs de tracking parfois très longues, cause d'une troncature réelle observée le 2026-08-29) : un index
+/// hors bornes est rejeté, ce qui offre la même garantie qu'avant contre une URL inventée.
 /// </summary>
 public static class EmailLinkExtractionResponseParser
 {
@@ -48,11 +49,9 @@ public static class EmailLinkExtractionResponseParser
                 throw new EmailLinkExtractionParseException("Champ 'links' manquant ou invalide.");
             }
 
-            var candidateSet = new HashSet<string>(candidateUrls, StringComparer.Ordinal);
-
             return linksElement.EnumerateArray()
-                .Select(ParseLink)
-                .Where(link => link is not null && candidateSet.Contains(link.Url))
+                .Select(element => ParseLink(element, candidateUrls))
+                .Where(link => link is not null)
                 .Cast<ExtractedLink>()
                 .DistinctBy(link => link.Url, StringComparer.Ordinal)
                 .Take(MaxLinks)
@@ -64,20 +63,18 @@ public static class EmailLinkExtractionResponseParser
         }
     }
 
-    private static ExtractedLink? ParseLink(JsonElement element)
+    private static ExtractedLink? ParseLink(JsonElement element, IReadOnlyList<string> candidateUrls)
     {
         if (element.ValueKind != JsonValueKind.Object
-            || !element.TryGetProperty("url", out var urlElement)
-            || urlElement.ValueKind != JsonValueKind.String)
+            || !element.TryGetProperty("index", out var indexElement)
+            || indexElement.ValueKind != JsonValueKind.Number
+            || !indexElement.TryGetInt32(out var index)
+            || index < 0 || index >= candidateUrls.Count)
         {
             return null;
         }
 
-        var url = urlElement.GetString();
-        if (string.IsNullOrWhiteSpace(url))
-        {
-            return null;
-        }
+        var url = candidateUrls[index];
 
         var title = element.TryGetProperty("title", out var titleElement) && titleElement.ValueKind == JsonValueKind.String
             ? titleElement.GetString()

--- a/tests/LoreAI.Infrastructure.Tests/Classification/AnthropicEmailLinkExtractorTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Classification/AnthropicEmailLinkExtractorTests.cs
@@ -26,7 +26,7 @@ public class AnthropicEmailLinkExtractorTests
                 .WithBody("""
                     { "id": "msg_1", "type": "message", "content": [
                       { "type": "tool_use", "id": "toolu_1", "name": "extract_links",
-                        "input": { "links": [ { "url": "https://blog.example.com/article", "title": "Un vrai article" } ] } }
+                        "input": { "links": [ { "index": 0, "title": "Un vrai article" } ] } }
                     ] }
                     """));
 
@@ -122,7 +122,7 @@ public class AnthropicEmailLinkExtractorTests
                 .WithBody("""
                     { "id": "msg_1", "type": "message", "content": [
                         { "type": "tool_use", "id": "toolu_1", "name": "extract_links",
-                          "input": { "links": [ { "url": "https://blog.example.com/article", "title": "Titre" } ] } } ] }
+                          "input": { "links": [ { "index": 0, "title": "Titre" } ] } } ] }
                     """));
 
         var (extractor, extractionLogRepository) = CreateExtractor(server);

--- a/tests/LoreAI.Infrastructure.Tests/Classification/EmailLinkExtractionPromptBuilderTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Classification/EmailLinkExtractionPromptBuilderTests.cs
@@ -49,4 +49,35 @@ public class EmailLinkExtractionPromptBuilderTests
         Assert.Equal("object", root.GetProperty("type").GetString());
         Assert.True(root.GetProperty("properties").TryGetProperty("links", out _));
     }
+
+    /// <summary>
+    /// Régression pour la troncature observée le 2026-08-29 : le modèle désigne un lien par index, jamais en
+    /// recopiant l'URL (coûteux en tokens pour des URLs de tracking longues) — vérifie que le schéma exige
+    /// bien "index" et que le message présente les candidates numérotées.
+    /// </summary>
+    [Fact]
+    public void BuildToolInputSchemaJson_LinksItemsRequireIndexNotUrl()
+    {
+        var schemaJson = EmailLinkExtractionPromptBuilder.BuildToolInputSchemaJson();
+
+        using var document = JsonDocument.Parse(schemaJson);
+        var itemProperties = document.RootElement
+            .GetProperty("properties").GetProperty("links")
+            .GetProperty("items").GetProperty("properties");
+
+        Assert.True(itemProperties.TryGetProperty("index", out _));
+        Assert.False(itemProperties.TryGetProperty("url", out _));
+    }
+
+    [Fact]
+    public void BuildUserMessage_NumbersCandidateUrls()
+    {
+        var message = EmailLinkExtractionPromptBuilder.BuildUserMessage(
+            "Sujet",
+            "Corps",
+            ["https://blog.example.com/article", "https://tools.example.com/cli"]);
+
+        Assert.Contains("[0] https://blog.example.com/article", message);
+        Assert.Contains("[1] https://tools.example.com/cli", message);
+    }
 }

--- a/tests/LoreAI.Infrastructure.Tests/Classification/EmailLinkExtractionResponseParserTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Classification/EmailLinkExtractionResponseParserTests.cs
@@ -15,8 +15,8 @@ public class EmailLinkExtractionResponseParserTests
     {
         const string json = """
             { "links": [
-                { "url": "https://blog.example.com/real-article", "title": "Un vrai article .NET" },
-                { "url": "https://tools.example.com/new-cli", "title": "Un nouvel outil CLI" }
+                { "index": 0, "title": "Un vrai article .NET" },
+                { "index": 1, "title": "Un nouvel outil CLI" }
             ] }
             """;
 
@@ -39,15 +39,15 @@ public class EmailLinkExtractionResponseParserTests
 
     /// <summary>
     /// Garde de sécurité propre à ce parseur (cf. F-11) : le modèle ne doit jamais pouvoir faire écrire
-    /// une URL qu'il aurait inventée ou légèrement modifiée par rapport aux URLs candidates fournies.
+    /// un lien qui ne figure pas dans les URLs candidates fournies.
     /// </summary>
     [Fact]
-    public void Parse_UrlNotInCandidateList_IsDropped()
+    public void Parse_IndexOutOfRange_IsDropped()
     {
         const string json = """
             { "links": [
-                { "url": "https://blog.example.com/real-article", "title": "Un vrai article" },
-                { "url": "https://evil.example.com/not-a-candidate", "title": "Inventé" }
+                { "index": 0, "title": "Un vrai article" },
+                { "index": 5, "title": "Hors bornes" }
             ] }
             """;
 
@@ -58,12 +58,22 @@ public class EmailLinkExtractionResponseParserTests
     }
 
     [Fact]
-    public void Parse_DuplicateUrls_KeepsOnlyFirstOccurrence()
+    public void Parse_NegativeIndex_IsDropped()
+    {
+        const string json = """{ "links": [ { "index": -1, "title": "Invalide" } ] }""";
+
+        var result = EmailLinkExtractionResponseParser.Parse(json, CandidateUrls);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Parse_DuplicateIndexes_KeepsOnlyFirstOccurrence()
     {
         const string json = """
             { "links": [
-                { "url": "https://blog.example.com/real-article", "title": "Titre 1" },
-                { "url": "https://blog.example.com/real-article", "title": "Titre 2" }
+                { "index": 0, "title": "Titre 1" },
+                { "index": 0, "title": "Titre 2" }
             ] }
             """;
 
@@ -76,7 +86,7 @@ public class EmailLinkExtractionResponseParserTests
     [Fact]
     public void Parse_MissingTitle_FallsBackToUrl()
     {
-        const string json = """{ "links": [ { "url": "https://blog.example.com/real-article" } ] }""";
+        const string json = """{ "links": [ { "index": 0 } ] }""";
 
         var result = EmailLinkExtractionResponseParser.Parse(json, CandidateUrls);
 


### PR DESCRIPTION
## Résumé

Une newsletter reçue le 2026-08-29 à 07:21 (*.NET Weekly* de Milan Jovanović) n'a pas pu être traitée : `AnthropicEmailLinkExtractor` a tronqué sa réponse (`stop_reason=max_tokens`, budget de 800 tokens). Comme le curseur `historyId` de Gmail avance inconditionnellement après traitement du batch, ce mail était perdu sans retry ni notification.

Cause racine : le schéma d'outil exigeait que le modèle recopie chaque URL candidate mot pour mot dans sa réponse. Les URLs candidates de cette newsletter (ConvertKit) encodent leur destination en base64 dans le chemin — chaque URL fait ~200+ caractères (~60-100 tokens). Avec une quinzaine de candidats, le budget de 800 tokens était épuisé avant la fin de la génération JSON.

## Changement

- `EmailLinkExtractionPromptBuilder` : les URLs candidates sont numérotées `[0] [1] ...` dans le prompt ; le schéma d'outil demande un `index` plutôt qu'une `url`.
- `EmailLinkExtractionResponseParser` : résout chaque lien retenu par son index dans la liste candidate (borne validée, index hors bornes rejeté) au lieu d'exiger une correspondance exacte de l'URL — même garantie qu'avant contre une URL inventée par le modèle, mais le coût en tokens par lien retenu tombe à quelques tokens au lieu d'une centaine, indépendamment de la longueur des URLs de tracking.
- Tests mis à jour (schéma, prompt, parser, extracteur) + régression explicite sur l'absence du champ `url` dans le schéma et la numérotation du prompt.

## Test plan

- [x] `dotnet build LoreAI.slnx` : 0 erreur
- [x] `dotnet test LoreAI.slnx` : 366/366 verts
- [ ] Reprocessing manuel du mail perdu du 2026-08-29 (la réponse brute Anthropic tronquée est déjà journalisée dans le repository d'usage LLM pour audit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EweNC4hzd5eXBwrD2KNjo3