### PR TITLE
feat: connecteur RSS via Miniflux (lot 7, #48)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,28 @@ Gmail__ClientSecret=
 Gmail__RefreshToken=
 Gmail__Label=
 
+# --- Connecteur RSS via Miniflux (lot 7, #48) : desactive par defaut, la section Miniflux__* ci-dessous
+# n'est validee au demarrage que si Worker__FeedIngestionEnabled=true (evite qu'un deploiement sans
+# instance Miniflux configuree echoue au demarrage).
+Worker__FeedIngestionEnabled=false
+Worker__FeedIngestionCronExpression=0 * * * *
+
+# Adresse interne du conteneur Miniflux (voir docker-compose.yml, service "miniflux") - DNS du reseau
+# Docker partage, pas une adresse Tailscale : les deux conteneurs sont colocalises.
+Miniflux__BaseUrl=http://miniflux:8080
+# Jeton API genere une fois dans l'UI Miniflux (Settings -> API Keys) - voir README pour la procedure
+# complete (creation du compte admin, ajout des flux, seed du curseur PollingStates).
+Miniflux__ApiToken=
+
+# --- Deploiement du conteneur "miniflux" lui-meme (docker-compose.yml) : base et role dedies sur
+# l'instance PostgreSQL mutualisee (ADR 0009), jamais la base "loreai" - voir
+# docs/deploiement-raspberry-pi.md pour le provisionnement SQL complet.
+MINIFLUX_DATABASE_URL=postgres://miniflux:@pg_main:5432/miniflux?sslmode=disable
+# Compte admin cree au tout premier demarrage (CREATE_ADMIN=1, idempotent) - sert a se connecter a l'UI
+# Miniflux pour ajouter des flux et generer le jeton API ci-dessus.
+MINIFLUX_ADMIN_USERNAME=
+MINIFLUX_ADMIN_PASSWORD=
+
 # --- Serveur MCP en lecture seule (lot 3, #44, ADR 0014) : conteneur "loreai-mcp" separe, voir
 # docker-compose.yml. Ne concerne pas le worker "loreai" ci-dessus.
 
@@ -75,5 +97,6 @@ MCP_POSTGRES_CONNECTION_STRING=Host=pg_main;Port=5432;Database=loreai;Username=l
 MCP_BEARER_TOKEN=
 
 # Adresse Tailscale du Pi sur laquelle le port MCP est publie - jamais 0.0.0.0 (D2/ADR 0010). A obtenir
-# sur mcm8 avec `tailscale ip -4`.
+# sur mcm8 avec `tailscale ip -4`. Reutilisee telle quelle par le service "miniflux" (lot 7, #48) : un
+# seul Pi, meme garde-fou reseau.
 MCP_TAILSCALE_BIND_IP=

--- a/README.md
+++ b/README.md
@@ -116,6 +116,24 @@ VALUES ('Newsletter', '<historyId_retourne_par_users.getProfile>', NULL, '<date_
 
 Sans cette ligne, `GmailIngester` refuse tout backfill et journalise un avertissement à chaque passage tant que le curseur n'est pas seedé.
 
+## Connecteur RSS via Miniflux (lot 7)
+
+Désactivé par défaut (`Worker__FeedIngestionEnabled=false`) : lit les nouvelles entrées d'une instance [Miniflux](https://miniflux.app/) auto-hébergée (tous flux confondus) et les classe comme les articles Raindrop — sans jamais rien réécrire dans Miniflux ni Raindrop (ADR 0012). Miniflux gère lui-même la liste d'abonnements, le parsing des flux et sert d'interface de lecture humaine (remplace Feedly) ; LoreAI ne fait que consommer ses entrées via son API REST.
+
+Prérequis, à faire une fois avant d'activer (`Worker__FeedIngestionEnabled=true`) — voir `docs/deploiement-raspberry-pi.md` pour le déploiement complet du conteneur Miniflux :
+
+1. **Déployer Miniflux** (service `miniflux` du `docker-compose.yml`) — sur sa propre base `miniflux` de l'instance PostgreSQL mutualisée du Pi (ADR 0009), jamais la base `loreai`.
+2. **Créer le compte admin** au premier démarrage (`ADMIN_USERNAME`/`ADMIN_PASSWORD`), s'y connecter, puis **ajouter les flux RSS souhaités** via son interface.
+3. **Générer un jeton API** : Settings → API Keys → Create a new API key → reporter dans `Miniflux__ApiToken`. Reporter aussi l'adresse interne du conteneur dans `Miniflux__BaseUrl` (ex. `http://miniflux:8080`, DNS du réseau Docker partagé).
+4. **Seeder le curseur d'entrée**, même logique que Gmail/Raindrop ci-dessus (jamais de backfill automatique) : récupérer l'id de la dernière entrée existante avec `curl -H "X-Auth-Token: <jeton>" "http://<miniflux>/v1/entries?order=id&direction=desc&limit=1"`, puis :
+
+```sql
+INSERT INTO "PollingStates" ("SourceType", "LastSourceItemId", "LastCreatedUtc", "UpdatedAtUtc")
+VALUES ('Feed', '<id_de_la_derniere_entree_a_ignorer>', NULL, '<date_ISO8601_UTC>');
+```
+
+Sans cette ligne, `MinifluxIngester` refuse tout backfill et journalise un avertissement à chaque passage tant que le curseur n'est pas seedé.
+
 ## Tests automatisés
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,24 @@ services:
     volumes:
       - ./data:/data
 
+  miniflux:
+    # Lot 7 (#48) : moteur d'ingestion RSS (via son API REST, consommee par MinifluxIngester) et interface
+    # de lecture humaine (remplace Feedly). Sa propre base "miniflux" sur l'instance PostgreSQL mutualisee
+    # (ADR 0009), jamais la base "loreai". RUN_MIGRATIONS/CREATE_ADMIN sont idempotents : sans effet une
+    # fois le schema/l'admin en place, pas besoin de les retirer apres le premier demarrage.
+    image: docker.io/miniflux/miniflux:${MINIFLUX_TAG:-2.2.12}
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: ${MINIFLUX_DATABASE_URL}
+      RUN_MIGRATIONS: 1
+      CREATE_ADMIN: 1
+      ADMIN_USERNAME: ${MINIFLUX_ADMIN_USERNAME}
+      ADMIN_PASSWORD: ${MINIFLUX_ADMIN_PASSWORD}
+    ports:
+      # Meme garde-fou D2/ADR 0010 que loreai-mcp : bind sur l'adresse Tailscale du Pi, jamais "8080:8080"
+      # seul (publierait sur 0.0.0.0). Meme IP que MCP_TAILSCALE_BIND_IP (un seul Pi).
+      - "${MCP_TAILSCALE_BIND_IP}:8080:8080"
+
 # Reseau Docker externe de l'instance PostgreSQL mutualisee (ADR 0009) : LoreAI la rejoint, il ne la
 # possede pas - stack Compose distincte, proprietaire de son propre reseau. Pas de depends_on vers un
 # service qu'il ne possede pas non plus : le worker demarre et reessaie si Postgres n'est pas encore

--- a/docs/deploiement-raspberry-pi.md
+++ b/docs/deploiement-raspberry-pi.md
@@ -208,3 +208,56 @@ La CD publie `ghcr.io/slucky31/loreai-mcp` au même rythme et avec la même vers
    ```
 
    `Now listening on: http://[::]:8080` confirme le démarrage ; une requête `initialize` sans jeton doit répondre `401`, avec le bon jeton `200` (voir `tests/LoreAI.Mcp.Tests` pour le comportement attendu du middleware).
+
+## 12. Lot 7 : déployer Miniflux (connecteur RSS, #48)
+
+Miniflux est le moteur d'ingestion RSS (via son API REST, consommée par `MinifluxIngester`) **et** l'interface de lecture humaine (remplace Feedly) — voir [roadmap.md](roadmap.md), section « Miniflux auto-hébergé ». Il tourne dans son propre conteneur (`miniflux`, `docker-compose.yml`), sur sa propre base de l'instance PostgreSQL mutualisée — jamais la base `loreai`.
+
+1. **Provisionner la base et le rôle**, comme à l'étape 3 mais pour Miniflux (superutilisateur de l'instance, dans n'importe quelle base pour la création des rôles) :
+
+   ```sql
+   CREATE DATABASE miniflux;
+   CREATE ROLE miniflux LOGIN PASSWORD '<mot_de_passe_a_choisir>';
+   GRANT ALL PRIVILEGES ON DATABASE miniflux TO miniflux;
+   ```
+
+   Puis, **connecté directement à la base `miniflux`** (ex. `psql "postgresql://<superutilisateur>@<hote>:5432/miniflux"` — jamais `\c`, non portable vers un client graphique) :
+
+   ```sql
+   GRANT ALL ON SCHEMA public TO miniflux;
+   ```
+
+   Miniflux applique ses propres migrations au démarrage (`RUN_MIGRATIONS=1`) : pas de schéma à créer à la main au-delà de ce `GRANT`.
+
+2. **Compléter `.env`** (clés déjà présentes dans `.env.example`) :
+
+   - `MINIFLUX_DATABASE_URL` : `postgres://miniflux:<mot_de_passe>@pg_main:5432/miniflux?sslmode=disable` (même host/réseau que `Postgres__ConnectionString`, base et rôle différents).
+   - `MINIFLUX_ADMIN_USERNAME` / `MINIFLUX_ADMIN_PASSWORD` : compte admin créé au premier démarrage (`CREATE_ADMIN=1`), servira à se connecter à l'UI.
+   - `MCP_TAILSCALE_BIND_IP` : déjà renseignée si le lot 3 est actif — réutilisée telle quelle (même Pi, même garde-fou D2/ADR 0010 : jamais `0.0.0.0`).
+
+3. **Démarrer et se connecter** :
+
+   ```bash
+   sudo docker compose pull
+   sudo docker compose up -d miniflux
+   sudo docker compose logs -f miniflux
+   ```
+
+   Ouvrir `http://<ip-tailscale-de-mcm8>:8080` depuis un poste sur le tailnet, se connecter avec le compte admin, puis **ajouter les flux RSS souhaités** via l'interface (« Add subscription »).
+
+4. **Générer le jeton API** : Settings → API Keys → Create a new API key → reporter dans `Miniflux__ApiToken` (`.env`, section worker). Reporter aussi `Miniflux__BaseUrl=http://miniflux:8080` (DNS interne du réseau Docker partagé, pas l'adresse Tailscale — le worker et Miniflux sont colocalisés).
+
+5. **Seeder le curseur d'entrée**, même logique que le « Premier démarrage » de Raindrop (étape 8) et le connecteur Gmail (README) : jamais de backfill automatique au premier démarrage.
+
+   ```bash
+   curl -H "X-Auth-Token: <jeton_genere_a_l_etape_4>" "http://<ip-tailscale-de-mcm8>:8080/v1/entries?order=id&direction=desc&limit=1"
+   ```
+
+   Récupérer le champ `id` de l'unique entrée retournée, puis :
+
+   ```sql
+   INSERT INTO "PollingStates" ("SourceType", "LastSourceItemId", "LastCreatedUtc", "UpdatedAtUtc")
+   VALUES ('Feed', '<id_recupere_ci_dessus>', NULL, '<date_ISO8601_UTC>');
+   ```
+
+6. **Activer le connecteur** : `Worker__FeedIngestionEnabled=true` dans `.env`, puis `sudo docker compose up -d loreai` pour redémarrer le worker avec la section `Miniflux__*` désormais validée au démarrage.

--- a/src/LoreAI.Core/Interfaces/IFeedIngester.cs
+++ b/src/LoreAI.Core/Interfaces/IFeedIngester.cs
@@ -1,0 +1,6 @@
+namespace LoreAI.Core.Interfaces;
+
+/// <summary>Marqueur vide (lot 7, #48), même patron que <see cref="IGmailIngester"/> : permet à l'appelant de demander spécifiquement l'ingesteur RSS/Miniflux sans ambiguïté DI.</summary>
+public interface IFeedIngester : ISourceIngester
+{
+}

--- a/src/LoreAI.Infrastructure/Feed/Dto/MinifluxApiDtos.cs
+++ b/src/LoreAI.Infrastructure/Feed/Dto/MinifluxApiDtos.cs
@@ -1,0 +1,21 @@
+using System.Text.Json.Serialization;
+
+namespace LoreAI.Infrastructure.Feed.Dto;
+
+/// <summary>Réponse de <c>GET /v1/entries</c> (API Miniflux, JSON snake_case).</summary>
+internal sealed class EntriesResponseDto
+{
+    public List<EntryDto> Entries { get; set; } = [];
+}
+
+internal sealed class EntryDto
+{
+    public long Id { get; set; }
+
+    public string Title { get; set; } = string.Empty;
+
+    public string Url { get; set; } = string.Empty;
+
+    [JsonPropertyName("published_at")]
+    public DateTimeOffset PublishedAt { get; set; }
+}

--- a/src/LoreAI.Infrastructure/Feed/MinifluxIngester.cs
+++ b/src/LoreAI.Infrastructure/Feed/MinifluxIngester.cs
@@ -1,0 +1,121 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+using LoreAI.Infrastructure.Feed.Dto;
+
+namespace LoreAI.Infrastructure.Feed;
+
+/// <summary>
+/// Consomme l'API REST d'une instance Miniflux auto-hébergée (lot 7, #48) : Miniflux possède la liste
+/// d'abonnements, parse les flux et sert d'interface de lecture humaine — cette classe ne fait que lire
+/// ses nouvelles entrées, tous flux confondus, via <c>GET /v1/entries</c>. Curseur = id d'entrée Miniflux
+/// (entier monotone côté serveur, cf. <c>after_entry_id</c>), même patron que <see cref="Gmail.GmailIngester"/> :
+/// cette classe persiste elle-même sa progression via <see cref="IPollingStateRepository"/>. Jamais de
+/// write-back vers Miniflux (jamais de <c>PUT /v1/entries</c>) : une source Feed n'est jamais réécrite
+/// (ADR 0012), et Miniflux reste l'interface de lecture, indépendante de l'ingestion LoreAI.
+/// </summary>
+public sealed class MinifluxIngester : IFeedIngester
+{
+    private const int MaxPagesPerCycle = 50;
+    private const int PageSize = 100;
+
+    private readonly HttpClient _httpClient;
+    private readonly IPollingStateRepository _pollingStateRepository;
+    private readonly ILogger<MinifluxIngester> _logger;
+
+    public MinifluxIngester(HttpClient httpClient, IOptions<MinifluxOptions> options, IPollingStateRepository pollingStateRepository, ILogger<MinifluxIngester> logger)
+    {
+        _httpClient = httpClient;
+        _pollingStateRepository = pollingStateRepository;
+        _logger = logger;
+
+        var minifluxOptions = options.Value;
+        _httpClient.BaseAddress ??= new Uri(minifluxOptions.BaseUrl.TrimEnd('/') + "/");
+        _httpClient.DefaultRequestHeaders.Remove("X-Auth-Token");
+        _httpClient.DefaultRequestHeaders.Add("X-Auth-Token", minifluxOptions.ApiToken);
+    }
+
+    public SourceType SourceType => SourceType.Feed;
+
+    public async Task<IReadOnlyList<Item>> GetNewItemsAsync(PollingState lastState, CancellationToken cancellationToken)
+    {
+        // Premier démarrage : jamais de backfill automatique, même choix que GmailIngester (pas celui de
+        // Raindrop) — sans garde, un premier cycle remonterait l'historique complet de tous les flux
+        // souscrits dans Miniflux. Le curseur se seed manuellement (voir README/guide de déploiement).
+        if (lastState.LastSourceItemId is null)
+        {
+            _logger.LogWarning(
+                "Aucun curseur d'entrée enregistré pour la source Feed : aucune entrée ne sera récupérée. " +
+                "Seeder PollingStates manuellement (voir README) pour amorcer le connecteur Miniflux.");
+            return [];
+        }
+
+        var (entries, lastEntryId) = await ListNewEntriesAsync(lastState.LastSourceItemId, cancellationToken);
+
+        var items = entries
+            .Select(entry => new Item(
+                SourceType.Feed,
+                entry.Id.ToString(CultureInfo.InvariantCulture),
+                entry.Url,
+                entry.Title,
+                null,
+                null,
+                [],
+                entry.PublishedAt))
+            .ToList();
+
+        if (lastEntryId is not null)
+        {
+            await _pollingStateRepository.UpdateAsync(
+                new PollingState(SourceType.Feed, lastEntryId, null, DateTimeOffset.UtcNow),
+                cancellationToken);
+        }
+
+        return items;
+    }
+
+    private async Task<(List<EntryDto> Entries, string? LastEntryId)> ListNewEntriesAsync(string afterEntryId, CancellationToken cancellationToken)
+    {
+        var entries = new List<EntryDto>();
+        var cursor = afterEntryId;
+        var page = 0;
+
+        do
+        {
+            var url = $"v1/entries?after_entry_id={Uri.EscapeDataString(cursor)}&order=id&direction=asc&limit={PageSize.ToString(CultureInfo.InvariantCulture)}";
+
+            var response = await _httpClient.GetAsync(url, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            var payload = await response.Content.ReadFromJsonAsync<EntriesResponseDto>(cancellationToken: cancellationToken)
+                ?? throw new InvalidOperationException("Réponse Miniflux /v1/entries vide ou invalide.");
+
+            entries.AddRange(payload.Entries);
+            if (payload.Entries.Count > 0)
+            {
+                cursor = payload.Entries[^1].Id.ToString(CultureInfo.InvariantCulture);
+            }
+
+            page++;
+            if (payload.Entries.Count < PageSize)
+            {
+                break;
+            }
+        }
+        while (page < MaxPagesPerCycle);
+
+        if (page >= MaxPagesPerCycle)
+        {
+            _logger.LogWarning(
+                "Plafond de {MaxPages} pages atteint pour /v1/entries : {Count} entrées récupérées, le reste sera repris au prochain cycle.",
+                MaxPagesPerCycle,
+                entries.Count);
+        }
+
+        return (entries, entries.Count > 0 ? cursor : null);
+    }
+}

--- a/src/LoreAI.Infrastructure/Feed/MinifluxOptions.cs
+++ b/src/LoreAI.Infrastructure/Feed/MinifluxOptions.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace LoreAI.Infrastructure.Feed;
+
+public sealed class MinifluxOptions
+{
+    /// <summary>Adresse de l'instance Miniflux auto-hébergée (lot 7, #48) — DNS interne du réseau Docker partagé (ex. <c>http://miniflux:8080</c>), jamais une adresse publique.</summary>
+    [Required(AllowEmptyStrings = false)]
+    [Url]
+    public required string BaseUrl { get; init; }
+
+    /// <summary>Jeton API généré une fois dans l'UI Miniflux (Settings → API Keys) — pas de flux OAuth, un seul jeton statique.</summary>
+    [Required(AllowEmptyStrings = false)]
+    public required string ApiToken { get; init; }
+}

--- a/src/LoreAI.Worker/Options/WorkerOptions.cs
+++ b/src/LoreAI.Worker/Options/WorkerOptions.cs
@@ -71,4 +71,15 @@ public sealed class WorkerOptions
     /// valide au démarrage — même logique que <see cref="WriteBackToRaindrop"/>.
     /// </summary>
     public bool EmailIngestionEnabled { get; init; }
+
+    /// <summary>Expression cron du connecteur RSS/Miniflux (lot 7, #48) — par défaut chaque heure, même cadence que le connecteur Gmail.</summary>
+    [Required(AllowEmptyStrings = false)]
+    public string FeedIngestionCronExpression { get; init; } = "0 * * * *";
+
+    /// <summary>
+    /// Inactif par défaut (lot 7, #48) : tant qu'aucune instance Miniflux n'est déployée/configurée (étape
+    /// manuelle, cf. guide de déploiement), le connecteur Feed ne doit ni être planifié, ni exiger une
+    /// section <c>Miniflux</c> valide au démarrage — même logique qu'<see cref="EmailIngestionEnabled"/>.
+    /// </summary>
+    public bool FeedIngestionEnabled { get; init; }
 }

--- a/src/LoreAI.Worker/Program.cs
+++ b/src/LoreAI.Worker/Program.cs
@@ -7,6 +7,7 @@ using LoreAI.Core.Interfaces;
 using LoreAI.Core.Services;
 using LoreAI.Infrastructure.Classification;
 using LoreAI.Infrastructure.Content;
+using LoreAI.Infrastructure.Feed;
 using LoreAI.Infrastructure.Gmail;
 using LoreAI.Infrastructure.Notifications;
 using LoreAI.Infrastructure.Persistence;
@@ -58,6 +59,14 @@ try
     if (emailIngestionEnabled)
     {
         builder.Services.AddValidatedOptions<GoogleOAuthOptions>(builder.Configuration, "Gmail");
+    }
+
+    // Même garde que ci-dessus, pour Miniflux (lot 7, #48) : tant qu'aucune instance n'est déployée/configurée,
+    // le worker continue de démarrer normalement plutôt que d'échouer sur une section Miniflux incomplète.
+    var feedIngestionEnabled = builder.Configuration.GetValue("Worker:FeedIngestionEnabled", false);
+    if (feedIngestionEnabled)
+    {
+        builder.Services.AddValidatedOptions<MinifluxOptions>(builder.Configuration, "Miniflux");
     }
 
     // IDbContextFactory plutôt qu'AddDbContext : les repositories restent des singletons (inchangé),
@@ -129,6 +138,14 @@ try
             .AddStandardResilienceHandler(ClassifierResilience.Configure);
 
         builder.Services.AddTransient<EmailIngestionJob>();
+    }
+
+    if (feedIngestionEnabled)
+    {
+        builder.Services.AddHttpClient<IFeedIngester, MinifluxIngester>()
+            .AddStandardResilienceHandler();
+
+        builder.Services.AddTransient<FeedIngestionJob>();
     }
 
     builder.Services.AddScheduler();
@@ -204,6 +221,13 @@ try
             scheduler.Schedule<EmailIngestionJob>()
                 .Cron(workerOptions.EmailIngestionCronExpression)
                 .PreventOverlapping(nameof(EmailIngestionJob));
+        }
+
+        if (workerOptions.FeedIngestionEnabled)
+        {
+            scheduler.Schedule<FeedIngestionJob>()
+                .Cron(workerOptions.FeedIngestionCronExpression)
+                .PreventOverlapping(nameof(FeedIngestionJob));
         }
     });
 

--- a/src/LoreAI.Worker/Services/FeedIngestionJob.cs
+++ b/src/LoreAI.Worker/Services/FeedIngestionJob.cs
@@ -1,0 +1,108 @@
+using Coravel.Invocable;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+
+namespace LoreAI.Worker.Services;
+
+/// <summary>
+/// Ingère les nouvelles entrées RSS/Atom via une instance Miniflux auto-hébergée (lot 7, #48) : Miniflux
+/// gère les abonnements et le parsing, <see cref="IFeedIngester"/> ne fait que lire ses entrées, puis
+/// classification + persistance via <see cref="ArticleClassificationStep"/> — jamais de write-back
+/// Raindrop ni Miniflux, une source Feed n'étant jamais réécrite (ADR 0012). Même patron
+/// qu'<c>EmailIngestionJob</c> : pas de <c>CycleRun</c> (réservé au cycle Raindrop, seul lu par le
+/// healthcheck) et un repli de classification n'interrompt pas le lot — le curseur est déjà avancé par
+/// <see cref="IFeedIngester"/>, indépendamment du sort de la classification de chaque entrée.
+/// </summary>
+public sealed class FeedIngestionJob : IInvocable, ICancellableInvocable
+{
+    private readonly IFeedIngester _feedIngester;
+    private readonly IPollingStateRepository _pollingStateRepository;
+    private readonly IRaindropClient _raindropClient;
+    private readonly ArticleClassificationStep _classificationStep;
+    private readonly ILogger<FeedIngestionJob> _logger;
+
+    public FeedIngestionJob(
+        IFeedIngester feedIngester,
+        IPollingStateRepository pollingStateRepository,
+        IRaindropClient raindropClient,
+        ArticleClassificationStep classificationStep,
+        ILogger<FeedIngestionJob> logger)
+    {
+        _feedIngester = feedIngester;
+        _pollingStateRepository = pollingStateRepository;
+        _raindropClient = raindropClient;
+        _classificationStep = classificationStep;
+        _logger = logger;
+    }
+
+    /// <summary>Alimenté par Coravel, annulé à l'arrêt de l'application (SIGTERM, <c>docker compose down</c>).</summary>
+    public CancellationToken CancellationToken { get; set; }
+
+    public async Task Invoke()
+    {
+        var cancellationToken = CancellationToken;
+
+        try
+        {
+            var lastState = await _pollingStateRepository.GetAsync(SourceType.Feed, cancellationToken);
+            var newItems = await _feedIngester.GetNewItemsAsync(lastState, cancellationToken);
+
+            if (newItems.Count == 0)
+            {
+                _logger.LogInformation("Aucune nouvelle entrée Feed à traiter.");
+                return;
+            }
+
+            var taxonomy = await _raindropClient.GetTaxonomyAsync(cancellationToken);
+            var processedCount = 0;
+            var fallbackCount = 0;
+
+            foreach (var item in newItems)
+            {
+                try
+                {
+                    var outcome = await _classificationStep.ProcessAsync(item, taxonomy, cancellationToken);
+                    if (outcome.Classification.IsFallback)
+                    {
+                        fallbackCount++;
+                        _logger.LogWarning(
+                            "Classification en repli pour l'entrée Feed {SourceId} ({Reason}) — persistée pour audit, lot non interrompu (curseur déjà avancé par l'ingesteur).",
+                            item.SourceId,
+                            outcome.Classification.Reason);
+                    }
+
+                    processedCount++;
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogInformation("Arrêt de l'application demandé — ingestion Feed interrompue proprement.");
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    // Contrairement à UnsortedClassificationJob, un échec ici ne remet pas en cause le
+                    // curseur (déjà avancé, indépendant des Item retournés) : on journalise et on continue
+                    // avec l'entrée suivante plutôt que d'interrompre tout le lot.
+                    _logger.LogError(ex, "Échec du traitement de l'entrée Feed {SourceId} — poursuite avec la suivante.", item.SourceId);
+                }
+            }
+
+            if (_logger.IsEnabled(LogLevel.Information))
+            {
+                _logger.LogInformation(
+                    "Ingestion Feed terminée : {ProcessedCount}/{NewCount} entrées traitées, {FallbackCount} en repli.",
+                    processedCount,
+                    newItems.Count,
+                    fallbackCount);
+            }
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            _logger.LogInformation("Ingestion Feed interrompue par l'arrêt de l'application.");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Échec de l'ingestion Feed.");
+        }
+    }
+}

--- a/tests/LoreAI.Infrastructure.Tests/Feed/MinifluxIngesterTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Feed/MinifluxIngesterTests.cs
@@ -1,0 +1,114 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+using LoreAI.Infrastructure.Feed;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace LoreAI.Infrastructure.Tests.Feed;
+
+public class MinifluxIngesterTests
+{
+    [Fact]
+    public async Task GetNewItemsAsync_NoCursor_ReturnsEmptyWithoutCallingApi()
+    {
+        using var server = WireMockServer.Start();
+        var (ingester, _) = CreateIngester(server);
+
+        var items = await ingester.GetNewItemsAsync(PollingState.Initial(SourceType.Feed), TestContext.Current.CancellationToken);
+
+        Assert.Empty(items);
+        Assert.Empty(server.LogEntries);
+    }
+
+    [Fact]
+    public async Task GetNewItemsAsync_NewEntries_ReturnsItemsAndAdvancesCursorToLastEntryId()
+    {
+        using var server = WireMockServer.Start();
+        GivenEntries(server, afterEntryId: "100", entries:
+        [
+            (101, "Un article", "https://blog.example.com/1", "2026-08-01T10:00:00Z"),
+            (102, "Un autre article", "https://blog.example.com/2", "2026-08-02T10:00:00Z"),
+        ]);
+
+        var (ingester, pollingStateRepository) = CreateIngester(server);
+
+        var items = await ingester.GetNewItemsAsync(
+            new PollingState(SourceType.Feed, "100", null, DateTimeOffset.UtcNow),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, items.Count);
+        Assert.Equal(SourceType.Feed, items[0].SourceType);
+        Assert.Equal("101", items[0].SourceId);
+        Assert.Equal("https://blog.example.com/1", items[0].Url);
+        Assert.Equal("Un article", items[0].Title);
+        Assert.Equal("102", items[1].SourceId);
+
+        await pollingStateRepository.Received(1).UpdateAsync(
+            Arg.Is<PollingState>(s => s!.SourceType == SourceType.Feed && s.LastSourceItemId == "102"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNewItemsAsync_NoNewEntries_ReturnsEmptyAndDoesNotAdvanceCursor()
+    {
+        using var server = WireMockServer.Start();
+        GivenEntries(server, afterEntryId: "100", entries: []);
+
+        var (ingester, pollingStateRepository) = CreateIngester(server);
+
+        var items = await ingester.GetNewItemsAsync(
+            new PollingState(SourceType.Feed, "100", null, DateTimeOffset.UtcNow),
+            TestContext.Current.CancellationToken);
+
+        Assert.Empty(items);
+        await pollingStateRepository.DidNotReceive().UpdateAsync(Arg.Any<PollingState>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNewItemsAsync_SendsApiTokenHeader()
+    {
+        using var server = WireMockServer.Start();
+        GivenEntries(server, afterEntryId: "100", entries: []);
+
+        var (ingester, _) = CreateIngester(server, apiToken: "secret-token");
+
+        await ingester.GetNewItemsAsync(
+            new PollingState(SourceType.Feed, "100", null, DateTimeOffset.UtcNow),
+            TestContext.Current.CancellationToken);
+
+        var request = Assert.Single(server.LogEntries);
+        Assert.Equal("secret-token", request.RequestMessage!.Headers!["X-Auth-Token"].Single());
+    }
+
+    private static void GivenEntries(WireMockServer server, string afterEntryId, IReadOnlyList<(long Id, string Title, string Url, string PublishedAt)> entries)
+    {
+        var entriesJson = string.Join(",", entries.Select(e =>
+            $$"""{ "id": {{e.Id}}, "title": {{System.Text.Json.JsonSerializer.Serialize(e.Title)}}, "url": {{System.Text.Json.JsonSerializer.Serialize(e.Url)}}, "published_at": {{System.Text.Json.JsonSerializer.Serialize(e.PublishedAt)}} }"""));
+
+        server
+            .Given(Request.Create()
+                .WithPath("/v1/entries")
+                .UsingGet()
+                .WithParam("after_entry_id", afterEntryId))
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json")
+                .WithBody($$"""{ "total": {{entries.Count}}, "entries": [ {{entriesJson}} ] }"""));
+    }
+
+    private static (MinifluxIngester Ingester, IPollingStateRepository PollingStateRepository) CreateIngester(WireMockServer server, string apiToken = "test-token")
+    {
+        var httpClient = new HttpClient();
+        var options = Options.Create(new MinifluxOptions
+        {
+            BaseUrl = server.Urls[0],
+            ApiToken = apiToken,
+        });
+        var pollingStateRepository = Substitute.For<IPollingStateRepository>();
+
+        return (new MinifluxIngester(httpClient, options, pollingStateRepository, NullLogger<MinifluxIngester>.Instance), pollingStateRepository);
+    }
+}

--- a/tests/LoreAI.Worker.Tests/Services/FeedIngestionJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/FeedIngestionJobTests.cs
@@ -1,0 +1,209 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using LoreAI.Core.Enums;
+using LoreAI.Core.Interfaces;
+using LoreAI.Core.Models;
+using LoreAI.Worker.Options;
+using LoreAI.Worker.Services;
+
+using MsOptions = Microsoft.Extensions.Options.Options;
+
+namespace LoreAI.Worker.Tests.Services;
+
+/// <summary>
+/// Couvre les garanties propres à ce job, distinctes d'<c>UnsortedClassificationJob</c> (lot 7, #48) :
+/// pas de write-back Raindrop ni Miniflux, pas de journal de cycle, et surtout un repli/échec sur une
+/// entrée n'interrompt pas le lot — le curseur d'entrée Miniflux est déjà avancé par IFeedIngester,
+/// indépendamment du sort de chaque item.
+/// </summary>
+public class FeedIngestionJobTests
+{
+    private static readonly RaindropTaxonomy EmptyTaxonomy = new([], []);
+
+    [Fact]
+    public async Task Invoke_NoNewItems_DoesNotLearnTaxonomyNorClassify()
+    {
+        var fixture = new JobFixture().WithNewItems();
+
+        await fixture.Build().Invoke();
+
+        await fixture.RaindropClient.DidNotReceive().GetTaxonomyAsync(Arg.Any<CancellationToken>());
+        await fixture.Classifier.DidNotReceive().ClassifyAsync(
+            Arg.Any<Item>(), Arg.Any<RaindropTaxonomy>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_NewItems_ClassifiesAndPersistsEachOne()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem("101"), CreateItem("102"))
+            .WithClassification(CreateClassification());
+
+        await fixture.Build().Invoke();
+
+        await fixture.Classifier.Received(2).ClassifyAsync(
+            Arg.Any<Item>(), Arg.Any<RaindropTaxonomy>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+        await fixture.ArticleRepository.Received(2).UpsertAsync(
+            Arg.Any<Item>(), Arg.Any<ClassificationResult>(), Arg.Any<ContentFetchResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Jamais de write-back Raindrop ni Miniflux pour une source Feed (ADR 0012).</summary>
+    [Fact]
+    public async Task Invoke_NewItem_NeverCallsRaindropWriteBack()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem("101"))
+            .WithClassification(CreateClassification());
+
+        await fixture.Build().Invoke();
+
+        await fixture.RaindropClient.DidNotReceive().UpdateRaindropAsync(
+            Arg.Any<long>(), Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<string>(), Arg.Any<long?>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Contrairement à UnsortedClassificationJob : un repli sur une entrée ne doit pas empêcher le
+    /// traitement des entrées suivantes, le curseur Miniflux étant déjà avancé indépendamment de chaque
+    /// classification.
+    /// </summary>
+    [Fact]
+    public async Task Invoke_FallbackOnFirstItem_StillProcessesSecondItem()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem("101"), CreateItem("102"))
+            .WithClassificationSequence(
+                ClassificationResult.Fallback("model", "boom", "{}"),
+                CreateClassification());
+
+        await fixture.Build().Invoke();
+
+        await fixture.ArticleRepository.Received(2).UpsertAsync(
+            Arg.Any<Item>(), Arg.Any<ClassificationResult>(), Arg.Any<ContentFetchResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>Même logique qu'un repli : une exception sur une entrée ne doit pas bloquer les suivantes.</summary>
+    [Fact]
+    public async Task Invoke_ExceptionOnFirstItem_StillProcessesSecondItem()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem("101"), CreateItem("102"))
+            .WithClassification(CreateClassification());
+        fixture.ArticleRepository
+            .UpsertAsync(Arg.Is<Item>(i => i!.SourceId == "101"), Arg.Any<ClassificationResult>(), Arg.Any<ContentFetchResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("database is locked"));
+
+        var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());
+
+        Assert.Null(exception);
+        await fixture.ArticleRepository.Received(1).UpsertAsync(
+            Arg.Is<Item>(i => i!.SourceId == "102"), Arg.Any<ClassificationResult>(), Arg.Any<ContentFetchResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Invoke_FeedIngesterThrows_DoesNotThrow()
+    {
+        var fixture = new JobFixture();
+        fixture.FeedIngester
+            .GetNewItemsAsync(Arg.Any<PollingState>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new HttpRequestException("401 Unauthorized"));
+
+        var exception = await Record.ExceptionAsync(() => fixture.Build().Invoke());
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task Invoke_PolicyTriggers_NotifiesImmediately()
+    {
+        var fixture = new JobFixture()
+            .WithNewItems(CreateItem("101"))
+            .WithClassification(CreateClassification());
+        fixture.NotificationPolicy.ShouldNotifyImmediately(Arg.Any<ClassificationResult>()).Returns(true);
+
+        await fixture.Build().Invoke();
+
+        await fixture.ImmediateNotifier.Received(1).NotifyAsync(
+            Arg.Any<Item>(), Arg.Any<ClassificationResult>(), Arg.Any<CancellationToken>());
+    }
+
+    private static Item CreateItem(string sourceId) => new(
+        SourceType.Feed,
+        sourceId,
+        $"https://blog.example.com/{sourceId}",
+        $"Article {sourceId}",
+        null,
+        null,
+        [],
+        DateTimeOffset.UtcNow);
+
+    private static ClassificationResult CreateClassification() =>
+        new(null, [], RecommendedAction.ALire, Priority.Moyenne, "raison", "résumé", "model", "{}");
+
+    private sealed class JobFixture
+    {
+        public IFeedIngester FeedIngester { get; } = Substitute.For<IFeedIngester>();
+        public IPollingStateRepository PollingStateRepository { get; } = Substitute.For<IPollingStateRepository>();
+        public IRaindropClient RaindropClient { get; } = Substitute.For<IRaindropClient>();
+        public IArticleRepository ArticleRepository { get; } = Substitute.For<IArticleRepository>();
+        public IClassifier Classifier { get; } = Substitute.For<IClassifier>();
+        public IContentFetcher ContentFetcher { get; } = Substitute.For<IContentFetcher>();
+        public IImmediateNotifier ImmediateNotifier { get; } = Substitute.For<IImmediateNotifier>();
+        public INotificationPolicy NotificationPolicy { get; } = Substitute.For<INotificationPolicy>();
+        public IToolRepository ToolRepository { get; } = Substitute.For<IToolRepository>();
+
+        public JobFixture()
+        {
+            PollingStateRepository.GetAsync(Arg.Any<SourceType>(), Arg.Any<CancellationToken>()).Returns(PollingState.Initial(SourceType.Feed));
+            FeedIngester.GetNewItemsAsync(Arg.Any<PollingState>(), Arg.Any<CancellationToken>()).Returns(Array.Empty<Item>());
+            RaindropClient.GetTaxonomyAsync(Arg.Any<CancellationToken>()).Returns(EmptyTaxonomy);
+            NotificationPolicy.ShouldNotifyImmediately(Arg.Any<ClassificationResult>()).Returns(false);
+            ContentFetcher.FetchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(ContentFetchResult.Skipped);
+            ArticleRepository
+                .UpsertAsync(Arg.Any<Item>(), Arg.Any<ClassificationResult>(), Arg.Any<ContentFetchResult>(), Arg.Any<DateTimeOffset>(), Arg.Any<CancellationToken>())
+                .Returns(1L);
+        }
+
+        public JobFixture WithNewItems(params Item[] items)
+        {
+            FeedIngester.GetNewItemsAsync(Arg.Any<PollingState>(), Arg.Any<CancellationToken>()).Returns(items);
+            return this;
+        }
+
+        public JobFixture WithClassification(ClassificationResult result)
+        {
+            Classifier.ClassifyAsync(Arg.Any<Item>(), Arg.Any<RaindropTaxonomy>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(result);
+            return this;
+        }
+
+        public JobFixture WithClassificationSequence(params ClassificationResult[] results)
+        {
+            Classifier.ClassifyAsync(Arg.Any<Item>(), Arg.Any<RaindropTaxonomy>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+                .Returns(results[0], results[1..]);
+            return this;
+        }
+
+        public FeedIngestionJob Build()
+        {
+            var options = MsOptions.Create(new WorkerOptions());
+            var classificationStep = new ArticleClassificationStep(
+                Classifier,
+                ContentFetcher,
+                ArticleRepository,
+                ImmediateNotifier,
+                NotificationPolicy,
+                ToolRepository,
+                options,
+                NullLogger<ArticleClassificationStep>.Instance);
+
+            return new FeedIngestionJob(
+                FeedIngester,
+                PollingStateRepository,
+                RaindropClient,
+                classificationStep,
+                NullLogger<FeedIngestionJob>.Instance);
+        }
+    }
+}


### PR DESCRIPTION
## Résumé

- `MinifluxIngester` (`IFeedIngester`) consomme `GET /v1/entries` d'une instance Miniflux auto-hébergée, curseur sur l'id d'entrée Miniflux — pas de backfill automatique au premier démarrage (même choix que `GmailIngester`, curseur à seeder manuellement).
- `FeedIngestionJob` classe chaque nouvelle entrée via `ArticleClassificationStep` (même pipeline que Raindrop/Gmail), sans jamais écrire dans Miniflux ni Raindrop (ADR 0012).
- Déploiement Miniflux ajouté au `docker-compose.yml` (service dédié, sa propre base sur l'instance PostgreSQL mutualisée — jamais la base `loreai`, port publié uniquement sur l'adresse Tailscale du Pi comme `loreai-mcp`).
- Désactivé par défaut (`Worker__FeedIngestionEnabled=false`).

## Changement d'arbitrage par rapport au roadmap initial

Le roadmap (lot 7, #48) prévoyait un `FeedIngester` parsant du XML directement (`System.ServiceModel.Syndication`). Décision prise en session : passer directement par **Miniflux auto-hébergé**, qui gère abonnements/parsing/santé des flux et sert aussi d'interface de lecture humaine (remplace Feedly) — couvrant en un seul déploiement les deux besoins identifiés dans l'arbitrage « Miniflux auto-hébergé » du roadmap, plutôt que de les séquencer. `docs/roadmap.md` sera mis à jour après merge pour refléter cette décision.

## Test plan

- [x] `dotnet build LoreAI.slnx` — succès
- [x] `dotnet test LoreAI.slnx` — 377/377 verts (Docker requis pour Testcontainers.PostgreSql)
- [ ] Déploiement réel sur `mcm8` (Miniflux + flux RSS + activation `Worker__FeedIngestionEnabled=true`) — hors CI, à faire manuellement par l'utilisateur (guide dans `docs/deploiement-raspberry-pi.md` section 12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyZNVJqxbbHuKANbWPs3Zx