### PR TITLE
fix: ReconciliationJob interroge Raindrop avec le mauvais id

### DIFF
--- a/src/LoreAI.Core/Models/ReconciliationCandidate.cs
+++ b/src/LoreAI.Core/Models/ReconciliationCandidate.cs
@@ -7,8 +7,11 @@ namespace LoreAI.Core.Models;
 /// écrit dans Raindrop (tags fusionnés = <see cref="OriginalTags"/> ∪ <see cref="SuggestedTags"/>,
 /// collection = <see cref="WriteBackCollectionId"/>) et décider d'une relance (L4).
 /// </summary>
+/// <param name="Id">Id technique (<c>Articles.Id</c>, généré par la base depuis le lot 8) — sert uniquement à ré-écrire la ligne via <see cref="Interfaces.IArticleRepository.RecordReconciliationAsync"/>, jamais à interroger Raindrop.</param>
+/// <param name="SourceId">Id Raindrop réel (le seul valable pour <see cref="Interfaces.IRaindropClient.GetRaindropAsync"/>) — cette source est toujours <c>SourceType.Raindrop</c>, filtré en amont par <see cref="Interfaces.IArticleRepository.GetReconciliationCandidatesAsync"/>.</param>
 public sealed record ReconciliationCandidate(
     long Id,
+    string SourceId,
     string Title,
     string Url,
     IReadOnlyList<string> OriginalTags,

--- a/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
+++ b/src/LoreAI.Infrastructure/Persistence/ArticleRepository.cs
@@ -150,12 +150,14 @@ public sealed class ArticleRepository : IArticleRepository
         await _schemaGuard.EnsureMigratedAsync(cancellationToken);
         await using var context = await _contextFactory.CreateDbContextAsync(cancellationToken);
 
+        // SourceType.Raindrop uniquement : c'est le seul qu'IRaindropClient.GetRaindropAsync sait
+        // interroger (Newsletter/Feed n'ont pas de raindrop à réconcilier — ADR 0012).
         return await context.Articles
-            .Where(a => a.LinkStatus != LinkStatus.Deleted)
+            .Where(a => a.SourceType == SourceType.Raindrop && a.LinkStatus != LinkStatus.Deleted)
             .OrderBy(a => a.LastSeenAtUtc)
             .Take(limit)
             .Select(a => new ReconciliationCandidate(
-                a.Id, a.Title, a.Url, a.OriginalTags, a.SuggestedTags, a.WriteBackCollectionId,
+                a.Id, a.SourceId, a.Title, a.Url, a.OriginalTags, a.SuggestedTags, a.WriteBackCollectionId,
                 a.RecommendedAction, a.Priority, a.ClassifiedAtUtc, a.HumanHandledAtUtc, a.RemindedAtUtc))
             .ToListAsync(cancellationToken);
     }

--- a/src/LoreAI.Worker/Services/ReconciliationJob.cs
+++ b/src/LoreAI.Worker/Services/ReconciliationJob.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Coravel.Invocable;
 using LoreAI.Core.Enums;
 using LoreAI.Core.Interfaces;
@@ -121,7 +122,10 @@ public sealed class ReconciliationJob : IInvocable, ICancellableInvocable
     private async Task<(LinkStatus LinkStatus, DateTimeOffset? HumanHandledAtUtc)> ReconcileOneAsync(
         ReconciliationCandidate candidate, DateTimeOffset now, CancellationToken cancellationToken)
     {
-        var snapshot = await _raindropClient.GetRaindropAsync(candidate.Id, cancellationToken);
+        // candidate.Id est l'id technique Articles.Id (généré par la base depuis le lot 8, #49) : jamais
+        // l'id Raindrop, qui vit dans SourceId depuis le passage au modèle multi-sources (ADR 0012).
+        var raindropId = long.Parse(candidate.SourceId, CultureInfo.InvariantCulture);
+        var snapshot = await _raindropClient.GetRaindropAsync(raindropId, cancellationToken);
         if (snapshot is null)
         {
             return (LinkStatus.Deleted, candidate.HumanHandledAtUtc);

--- a/tests/LoreAI.Infrastructure.Tests/Persistence/ArticleRepositoryTests.cs
+++ b/tests/LoreAI.Infrastructure.Tests/Persistence/ArticleRepositoryTests.cs
@@ -172,6 +172,27 @@ public class ArticleRepositoryTests : IAsyncLifetime
         Assert.Contains(all, a => a.SourceType == SourceType.Newsletter && a.Title == "Lien newsletter");
     }
 
+    /// <summary>
+    /// Régression : <c>GetReconciliationCandidatesAsync</c> ne doit renvoyer que des articles Raindrop
+    /// (seule source qu'<c>IRaindropClient.GetRaindropAsync</c> sait interroger), et exposer le vrai id
+    /// Raindrop via <c>SourceId</c> — jamais <c>Id</c>, l'id technique généré par la base depuis le lot 8.
+    /// </summary>
+    [Fact]
+    public async Task GetReconciliationCandidatesAsync_ExcludesNonRaindropSourcesAndExposesSourceId()
+    {
+        var raindropItem = CreateItem(42, "Article Raindrop");
+        var newsletterItem = raindropItem with { SourceType = SourceType.Newsletter, SourceId = "42", Title = "Lien newsletter" };
+        await _repository.UpsertAsync(raindropItem, CreateClassification(), ContentFetchResult.Skipped, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+        await _repository.UpsertAsync(newsletterItem, CreateClassification(), ContentFetchResult.Skipped, DateTimeOffset.UtcNow, TestContext.Current.CancellationToken);
+
+        var candidates = await _repository.GetReconciliationCandidatesAsync(10, TestContext.Current.CancellationToken);
+
+        var single = Assert.Single(candidates);
+        Assert.Equal("Article Raindrop", single.Title);
+        Assert.Equal("42", single.SourceId);
+        Assert.NotEqual(single.Id, long.Parse(single.SourceId, CultureInfo.InvariantCulture));
+    }
+
     [Fact]
     public async Task GetClassificationRawResponsesSinceAsync_ExcludesArticlesClassifiedBeforeCutoff()
     {

--- a/tests/LoreAI.Worker.Tests/Services/ReconciliationJobTests.cs
+++ b/tests/LoreAI.Worker.Tests/Services/ReconciliationJobTests.cs
@@ -169,8 +169,30 @@ public class ReconciliationJobTests
             1, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), Arg.Any<LinkStatus>(), Arg.Any<CancellationToken>());
     }
 
+    /// <summary>
+    /// Régression : <c>Articles.Id</c> (id technique, généré par la base depuis le lot 8) et l'id Raindrop
+    /// réel (<c>SourceId</c>) ont délibérément des valeurs différentes ici — un job qui interrogerait
+    /// Raindrop avec <c>candidate.Id</c> au lieu de <c>candidate.SourceId</c> échouerait ce test.
+    /// </summary>
+    [Fact]
+    public async Task Invoke_ArticleIdDiffersFromRaindropSourceId_QueriesRaindropWithSourceId()
+    {
+        var candidate = CreateCandidate(id: 999, sourceId: "1");
+        var fixture = new JobFixture().WithCandidates(candidate);
+        fixture.RaindropClient.GetRaindropAsync(1, Arg.Any<CancellationToken>())
+            .Returns(new RaindropSnapshot(1, -1, [], Broken: false));
+
+        await fixture.Build().Invoke();
+
+        await fixture.RaindropClient.Received(1).GetRaindropAsync(1, Arg.Any<CancellationToken>());
+        await fixture.RaindropClient.DidNotReceive().GetRaindropAsync(999, Arg.Any<CancellationToken>());
+        await fixture.ArticleRepository.Received(1).RecordReconciliationAsync(
+            999, Arg.Any<DateTimeOffset>(), Arg.Any<DateTimeOffset?>(), Arg.Any<DateTimeOffset?>(), LinkStatus.Ok, Arg.Any<CancellationToken>());
+    }
+
     private static ReconciliationCandidate CreateCandidate(
         long id,
+        string? sourceId = null,
         IReadOnlyList<string>? originalTags = null,
         IReadOnlyList<string>? suggestedTags = null,
         long? writeBackCollectionId = null,
@@ -179,7 +201,7 @@ public class ReconciliationJobTests
         DateTimeOffset? classifiedAtUtc = null,
         DateTimeOffset? humanHandledAtUtc = null,
         DateTimeOffset? remindedAtUtc = null) =>
-        new(id, $"Titre {id}", $"https://example.com/{id}",
+        new(id, sourceId ?? id.ToString(System.Globalization.CultureInfo.InvariantCulture), $"Titre {id}", $"https://example.com/{id}",
             originalTags ?? [], suggestedTags ?? [], writeBackCollectionId,
             action, priority, classifiedAtUtc ?? Now.AddDays(-1), humanHandledAtUtc, remindedAtUtc);
 


### PR DESCRIPTION
## Résumé

Découvert en creusant l'implémentation de L5 (roadmap) : depuis le refactor multi-sources du lot 8 (PR #81), `Articles.Id` est un id **technique généré par la base**, décorrélé de l'id Raindrop réel — qui vit désormais dans `SourceId` (clé applicative `(SourceType, SourceId)`, ADR 0012). `ReconciliationJob` continuait pourtant d'appeler :

```csharp
var snapshot = await _raindropClient.GetRaindropAsync(candidate.Id, cancellationToken);
```

— avec `candidate.Id` (l'id base), **pas** l'id Raindrop réel. `GetReconciliationCandidatesAsync` ne filtrait en plus pas sur `SourceType == Raindrop` : les articles Gmail/Feed y passaient aussi, alors qu'ils n'ont aucun raindrop à réconcilier.

**Impact** : depuis le lot 8 (tout article traité récemment), la réconciliation interroge un id qui n'est plus le bon — 404 (marqué à tort `LinkStatus.Deleted`) ou, par coïncidence, un tout autre raindrop du compte. Ça fausse potentiellement N3 (liens morts), N4 (péremption), L1 (file de lecture, filtrée sur `HumanHandledAtUtc`) et L4 (relances), tous alimentés par cette réconciliation — qui tourne déjà en prod (cron quotidien 2h UTC).

## Correctif

- `ReconciliationCandidate` porte désormais `SourceId` (l'id Raindrop réel) en plus de `Id` (id technique, utilisé uniquement pour ré-écrire la ligne en base).
- `GetReconciliationCandidatesAsync` filtre `SourceType == Raindrop` (seule source qu'`IRaindropClient.GetRaindropAsync` sait interroger).
- `ReconciliationJob` parse `SourceId` plutôt que `Id` pour l'appel Raindrop.
- Tests : régression côté `ReconciliationJobTests` (id technique ≠ `SourceId`, vérifie que Raindrop est interrogé avec le bon) et côté `ArticleRepositoryTests` (filtre `SourceType`, exposition de `SourceId`).

## Test plan

- [x] `dotnet build LoreAI.slnx` — succès
- [x] `dotnet test LoreAI.slnx` — 381/381 verts (Docker requis pour Testcontainers.PostgreSql)
- [ ] Vérification en prod (`mcm8`) au prochain passage naturel du cron de réconciliation — pas testable en CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyZNVJqxbbHuKANbWPs3Zx