### PR TITLE
fix: commande docker de --add-watch-topic ne doit pas répéter l'ENTRYPOINT

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ Prérequis, à faire une fois avant d'activer (`Worker__TopicWatchEnabled=true`)
    dotnet LoreAI.Worker.dll --add-watch-topic --name="dotnet-perf" --description="Optimisations de performance .NET, benchmarks, GC"
    ```
 
-   La commande crée la collection Raindrop et la catégorie Miniflux dédiées (même nom que `--name`), seed le curseur (aucun backfill : la catégorie vient d'être créée, donc vide), et persiste le sujet en base. Sur Docker, lancer via `docker compose run --rm loreai-worker dotnet LoreAI.Worker.dll --add-watch-topic --name=... --description=...`.
+   La commande crée la collection Raindrop et la catégorie Miniflux dédiées (même nom que `--name`), seed le curseur (aucun backfill : la catégorie vient d'être créée, donc vide), et persiste le sujet en base. Sur Docker, l'image a déjà `dotnet LoreAI.Worker.dll` en `ENTRYPOINT` — ne pas le répéter, seuls les arguments se passent à `docker compose run` : `docker compose run --rm loreai-worker --add-watch-topic --name=... --description=...`.
 2. **Ajouter les flux RSS de recherche** dans la catégorie Miniflux fraîchement créée, via l'UI (Settings → Feeds → Add).
 3. Répéter pour chaque sujet souhaité.
 

--- a/docs/deploiement-raspberry-pi.md
+++ b/docs/deploiement-raspberry-pi.md
@@ -270,8 +270,10 @@ Réutilise l'instance Miniflux déployée à l'étape 12. Chaque sujet a sa prop
 2. **Créer un sujet** :
 
    ```bash
-   sudo docker compose run --rm loreai-worker dotnet LoreAI.Worker.dll --add-watch-topic --name="dotnet-perf" --description="Optimisations de performance .NET, benchmarks, GC"
+   sudo docker compose run --rm loreai-worker --add-watch-topic --name="dotnet-perf" --description="Optimisations de performance .NET, benchmarks, GC"
    ```
+
+   L'image a déjà `dotnet LoreAI.Worker.dll` en `ENTRYPOINT` (`src/LoreAI.Worker/Dockerfile`) — ne pas le répéter dans la commande, sous peine de le passer en argument à lui-même.
 
    La commande crée la collection Raindrop et la catégorie Miniflux dédiées (même nom que `--name`), seed le curseur (catégorie fraîchement créée, donc vide — aucun backfill), et persiste le sujet en base. Répéter pour chaque sujet souhaité.
 3. **Ajouter les flux RSS de recherche** dans la catégorie Miniflux créée à l'étape 2 (Google News RSS `?q=...` ou équivalent), via l'UI Miniflux (`http://<ip-tailscale-de-mcm8>:5100`) — jamais dans la catégorie par défaut utilisée par le lot 7.


### PR DESCRIPTION
## Résumé

`docs/deploiement-raspberry-pi.md` §13 et le README documentaient `docker compose run --rm loreai-worker dotnet LoreAI.Worker.dll --add-watch-topic ...` — mais l'image a déjà `dotnet LoreAI.Worker.dll` en `ENTRYPOINT` (`src/LoreAI.Worker/Dockerfile`). `docker compose run <service> <args>` ajoute `<args>` **après** l'ENTRYPOINT, donc la commande documentée exécutait en réalité `dotnet LoreAI.Worker.dll dotnet LoreAI.Worker.dll --add-watch-topic ...`, ce qui échoue.

Repéré par l'utilisateur en testant la commande en prod sur `mcm8`. Commande corrigée :

```bash
docker compose run --rm loreai-worker --add-watch-topic --name="dotnet-perf" --description="..."
```

Docs uniquement, aucun changement de code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyZNVJqxbbHuKANbWPs3Zx