### PR TITLE
docs: revue fonctionnelle, roadmap phase 3 et plan de vérification

### DIFF
--- a/docs/critique-fonctionnelle.md
+++ b/docs/critique-fonctionnelle.md
@@ -1,0 +1,210 @@
+# Critique fonctionnelle — état réel de LoreAI
+
+> Revue faite le **2026-08-30**, sur `main` à la version **0.20.0** (+ le correctif `7b83b5f`).
+> Complément de [`etat-des-lieux.md`](etat-des-lieux.md) (où on en est) et de [`roadmap.md`](roadmap.md) (où on va) :
+> ce document dit **ce qui ne va pas**, avec la preuve à chaque fois.
+> Les suites concrètes sont loties dans [`roadmap-phase-3.md`](roadmap-phase-3.md).
+
+## Méthode
+
+Lecture de `src/` (14 700 lignes, 4 projets), des 22 issues ouvertes, du `.env.example`, des `Dockerfile` et du `docker-compose.yml`. Les chiffres de corpus viennent d'un appel réel au serveur MCP de production (`stats`, 2026-08-30) :
+
+```
+totalItems: 1369 · importantItems: 0 · brokenItems: 0 · lastIndexedAtUtc: 2026-08-30T12:26Z
+```
+
+Aucun constat ci-dessous n'est déduit de la documentation seule : chacun est adossé à un fichier, une issue ou une mesure.
+
+---
+
+## Ce qui marche, et qu'il faut arrêter de rediscuter
+
+Il faut le dire avant la critique, parce que c'est l'essentiel et que ça ne se voit plus dans les tickets ouverts.
+
+- **Le pipeline central tient.** `Item` générique, `ISourceIngester`, classification par tool-use forcé avec re-validation défensive, repli qui ne perd jamais un article, write-back conditionné à une correspondance exacte de collection vérifiée en code. C'est la partie la mieux conçue du projet et elle n'a jamais eu besoin d'être reprise depuis l'ADR 0012.
+- **L'observabilité de base existe** : `CycleRuns`, healthcheck Docker, compte-rendu Discord de fin de cycle. Le trou « le worker ne sait rien de son dernier cycle », qui bloquait deux issues depuis le début, est fermé.
+- **Le corpus est réellement constitué** : 1 369 items indexés, indexation fraîche de moins de 4 heures au moment de la revue. Le prérequis n°1 de la roadmap (« le corpus est presque vide ») n'est plus vrai — c'est la condition qui débloque tout le reste.
+- **Le MCP est la bonne réponse au bon problème.** 11 outils en lecture seule, rôle `loreai_ro`, tailnet. Il fait de Claude Code le front-end du corpus sans une ligne d'interface à écrire.
+- **La chaîne de livraison est saine** : Conventional Commits → Versionize → image multi-arch sur GHCR, le Pi ne fait que `pull`. 431 tests verts.
+
+La critique qui suit ne remet aucun de ces points en cause.
+
+---
+
+## Constats
+
+Gravité : 🔴 à traiter en priorité · 🟠 à planifier · 🟡 dette froide.
+
+### F1 🔴 — L'écart entre « livré » et « actif » n'est plus tenable
+
+Quatre fonctionnalités sur les six dernières livrées sont **désactivées par défaut** et leur état réel en production n'est pas connu :
+
+| Flag | Défaut | Fonctionnalité | État réel sur `mcm8` |
+|---|---|---|---|
+| `Worker__EmailIngestionEnabled` | `false` | Newsletters Gmail (lot 8) | inconnu |
+| `Worker__FeedIngestionEnabled` | `false` | Flux RSS perso (lot 7) | inconnu |
+| `Worker__ReadingQueueTaggingEnabled` | `false` | File de lecture taguée (L5) | inconnu |
+| `Worker__TopicWatchEnabled` | `false` | Veille sur sujets (lot 9) | inconnu |
+
+`etat-des-lieux.md` l'écrit lui-même : *« l'état exact des flags d'activation n'a pas été revérifié […] se fier au `.env` réel sur `mcm8`, pas à cette ligne »*. Autrement dit : **le projet ne sait pas ce qu'il fait tourner.**
+
+Ce n'est pas un défaut de rigueur documentaire, c'est un défaut de conception : rien dans le produit ne dit son propre état de configuration. Le worker démarre, planifie ou non des jobs selon des booléens, et n'en journalise jamais la synthèse. C'est exactement ce que demande [#65](https://github.com/slucky31/LoreAI/issues/65), qui est ouvert depuis le 24 août et n'a jamais été loti.
+
+Conséquence secondaire, plus gênante : **chaque nouveau lot ajoute un flag `false` par défaut**, donc un lot livré est un lot qui ne produit rien tant qu'une action manuelle non tracée n'a pas eu lieu sur le Pi. Le rythme de livraison a dépassé le rythme d'activation.
+
+### F2 🔴 — Le coût LLM n'est mesuré qu'a posteriori, une fois par semaine
+
+`LlmUsageAnalyzer` (S6) fait ce qu'on lui demande : il agrège les tokens du mois courant depuis `Articles.ClassificationRawResponse` et estime le coût. Mais c'est **un constat hebdomadaire, jamais un garde-fou** — aucun code du projet ne peut refuser un appel LLM parce que le budget est dépassé.
+
+Le lot 7 en a fait la démonstration grandeur nature : la classification de tous les flux RSS personnels a été livrée sans que son coût soit modélisé (le tableau de coût de la roadmap ne couvre que « Non trié »), et [#99](https://github.com/slucky31/LoreAI/issues/99) chiffre après coup ~36 $/mois à 100 entrées/jour — **3,5× le budget de référence de 10 €/mois**, découvert par lecture de code, pas par une alerte.
+
+Trois angles morts s'ajoutent :
+
+1. **La mesure est incomplète.** S6 ne lit que `Articles.ClassificationRawResponse`. Les appels d'extraction de liens de newsletter (`EmailExtractionLogs`) et de filtrage de veille (`WatchEvaluationLogs`) sont facturés mais comptés ailleurs, ou pas comptés du tout.
+2. **La granularité est fausse.** Le rapport donne un total mensuel, pas un coût par job. Impossible de répondre à « qu'est-ce qui coûte cher ? » — la question que pose précisément #99.
+3. **Le cache de prompt reste non mesuré** ([#34](https://github.com/slucky31/LoreAI/issues/34)). L'arbitrage de la roadmap est solide sur le papier (seuil 4 096 tokens Haiku vs préfixe stable ~900), mais il repose sur une estimation de tokens, jamais sur une lecture de `cache_creation_input_tokens`. La mesure était annoncée à 30 minutes ; elle n'a pas été faite.
+
+### F3 🟠 — La classification des flux RSS personnels ne produit rien d'exploitable
+
+C'est le sujet de [#99](https://github.com/slucky31/LoreAI/issues/99), déjà instruit et décidé. Je le confirme à la lecture du code : `FeedIngestionJob` classe chaque entrée, persiste, et **n'écrit jamais nulle part** (invariant ADR 0012). La seule valeur produite est une alerte Discord occasionnelle et l'alimentation du catalogue d'outils.
+
+Le vrai défaut n'est pas le coût, c'est le **cadrage de la source** : « Non trié » est borné par ce que l'humain choisit de sauvegarder ; un abonnement RSS est borné par ce que les éditeurs publient. Brancher un pipeline payant sur une source non bornée sans plafond était l'erreur, pas le connecteur lui-même.
+
+### F4 🟠 — Les surlignages sont collectés et jamais lus
+
+`LibraryItem.HighlightsJson` est mappé, stocké en `jsonb`, et **aucun code ne le relit** (vérifié : les seules occurrences hors migrations sont la définition d'entité, le mapping du repository, et un commentaire disant que `LibraryItemSummary` ne les inclut pas).
+
+La roadmap disait pourtant, au lot 1 : *« les surlignages sont la matière première idéale pour la synthèse, et ils sont perdus à chaque cycle »*. Ils ne sont plus perdus — ils sont archivés sans usage. Or c'est la donnée la plus dense du corpus : un surlignage est un jugement humain explicite, plus fiable qu'un tag et infiniment plus fiable qu'un score LLM.
+
+### F5 🟠 — La détection de liens morts repose sur un signal vide
+
+`importantItems: 0` et `brokenItems: 0` sur **1 369 items**. Les deux champs sont correctement mappés depuis l'API (`RaindropClient.cs:234-235`) : ce n'est pas un bug de code, c'est que Raindrop ne renseigne pas `broken` sur ce compte et que la fonction « important » n'est pas utilisée.
+
+Conséquence : **N3 (liens morts) et la section correspondante du rapport hebdomadaire ne produiront jamais rien**, et `BrokenTrackedArticlesAnalyzer` tourne pour rien. Le scénario avait été coté « effort 2, deux lignes de mapping, évite d'écrire un crawler » — l'économie était réelle, mais elle achetait un champ qui reste à zéro. Soit on assume qu'il n'y a pas de liens morts, soit il faut réellement sonder les URLs, ce qui est le crawler qu'on avait voulu éviter.
+
+### F6 🟠 — Cinq issues livrées sont toujours ouvertes
+
+Vérifié dans le code, pas dans la doc :
+
+| Issue | Prétendument à faire | Réalité |
+|---|---|---|
+| [#31](https://github.com/slucky31/LoreAI/issues/31) Compte-rendu de cycle Discord | ouvert | **livré** — `DiscordCycleReportNotifier`, règle « pas d'import, pas de notification » appliquée |
+| [#35](https://github.com/slucky31/LoreAI/issues/35) Healthcheck Docker/Portainer | ouvert | **livré** — `HEALTHCHECK` en forme exec, `Worker/Dockerfile:58` |
+| [#71](https://github.com/slucky31/LoreAI/issues/71) Logs en heure de Paris | ouvert | **livré** — `zoneinfo` copié depuis l'étage build + `ENV TZ=Europe/Paris`, dans les **deux** Dockerfiles |
+| [#73](https://github.com/slucky31/LoreAI/issues/73) Lien projet dans la base d'outils | ouvert | **livré** — `toolUrl` dans le schéma du tool `classify`, migration `AddToolUrl`, parsing borné à 300 caractères |
+| [#75](https://github.com/slucky31/LoreAI/issues/75) Déclenchement manuel des jobs lents | ouvert | **livré** — `--run-weekly-insights` / `--run-monthly-review`, `Program.cs:214-226` |
+
+Cinq faux positifs sur vingt-deux, soit **près d'un quart du backlog visible qui ment**. C'est ce qui rend la lecture des tickets ouverts inutilisable comme état des lieux, et c'est aussi ce qui fait qu'on relit la roadmap au lieu de regarder GitHub.
+
+### F7 🟡 — Trois issues sont périmées
+
+- [#36](https://github.com/slucky31/LoreAI/issues/36) « Renommer `raindropai-config-raindropai-1` » — le `docker-compose.yml` actuel déclare `loreai-worker`, `loreai-mcp`, `miniflux`. Sans objet.
+- [#39](https://github.com/slucky31/LoreAI/issues/39) « Déploiement Pi » — décrit l'édition manuelle de `image:` et parle de `/data/raindropai.db`, qui n'existe plus depuis le passage à PostgreSQL (ADR 0009). Le déploiement est aujourd'hui documenté et se fait par `pull` d'image GHCR.
+- [#33](https://github.com/slucky31/LoreAI/issues/33) « Comparaison Versionize avec repo comic » — corps vide, et Versionize fonctionne (12 releases automatiques, jusqu'à 0.20.0). Sans énoncé, il n'y a rien à trancher.
+
+### F8 🔴 — Renovate est bloqué, et personne ne le voit
+
+[#40](https://github.com/slucky31/LoreAI/issues/40) est ouvert depuis longtemps avec le message « Renovate will stop PRs until it is resolved ». La cause est dans `renovate.json`, ligne 5 : **une virgule manquante**.
+
+```jsonc
+"extends": [
+  "config:recommended",
+  "helpers:pinGitHubActionDigests"   // ← virgule absente
+  ":label(renovate)",
+```
+
+Conséquence concrète : **aucune mise à jour de dépendance n'est proposée** sur un projet .NET 10 qui centralise pourtant ses versions dans `Directory.Packages.props` et épingle les digests d'actions GitHub. C'est le correctif au meilleur rapport valeur/effort de tout le backlog — un caractère.
+
+### F9 🔴 — Il n'y a aucune sauvegarde
+
+[#37](https://github.com/slucky31/LoreAI/issues/37) est ouvert avec pour tout contenu « Quelles solutions ? ». La roadmap avait pourtant posé la règle au lot 0 : *« Mettre en place la sauvegarde `pg_dump` planifiée **avant** de supprimer le `.db` »*. Le `.db` a été supprimé. Rien n'indique que le `pg_dump` existe.
+
+Deux actifs sont exposés, et ils ne se sauvegardent pas de la même façon :
+
+1. **La base `loreai`** — 1 369 items indexés, tout l'historique de classification, les réponses LLM brutes qui portent la mesure de coût, les curseurs de polling. Sa perte n'est pas rattrapable par un ré-import : les curseurs perdus déclenchent un backfill complet, donc une facture LLM.
+2. **Le fichier `.env` sur `mcm8`** — token Raindrop, clé Anthropic, refresh token Google, jeton API Miniflux, jeton bearer MCP, mots de passe PostgreSQL. Aucun de ces secrets n'existe ailleurs. Le perdre, c'est reprovisionner sept identités à la main, dont un consentement OAuth Google interactif.
+
+C'est, de loin, le risque le plus élevé du projet aujourd'hui — devant le coût LLM.
+
+### F10 🟠 — Le token Raindrop est partagé par six jobs sans aucun pacing
+
+[#86](https://github.com/slucky31/LoreAI/issues/86) documente une rafale observée le 2026-08-29 : 148 appels séquentiels de `ReconciliationJob` → 429, puis timeout Polly, puis ~25 × 403 (bannissement temporaire du token).
+
+Le ticket propose un pacing **dans `ReconciliationJob`**. C'est la bonne intention au mauvais endroit. À la lecture de `Program.cs`, **six jobs partagent le même `IRaindropClient` et donc le même token** : `UnsortedClassificationJob` (toutes les 15 min), `LibraryIndexingJob`, `WeeklyInsightsJob`, `ReconciliationJob`, `ReadingQueueTaggingJob`, `TopicWatchJob`. Plusieurs de leurs crons se croisent volontairement (dimanche 3h / 4h / 4h05). Un limiteur posé dans un seul job ne protège pas des cinq autres.
+
+Le bon niveau est le client HTTP : un limiteur de débit partagé dans `RaindropClient`, pas un `Task.Delay` dans une boucle de job.
+
+### F11 🟠 — Aucune donnée n'est jamais purgée
+
+Vérifié : aucun `Delete`, `Purge` ni politique de rétention dans les repositories.
+
+| Table | Croissance | Justification actuelle |
+|---|---|---|
+| `CycleRuns` | ~96 lignes/jour, soit **~35 000/an** | le healthcheck n'en lit que **3** |
+| `Articles.ClassificationRawResponse` | une réponse Anthropic complète par article | nécessaire à S6 — mais S6 ne regarde que le mois courant |
+| `WatchEvaluationLogs` | une ligne par candidat de veille évalué | « log d'audit minimal » |
+| `EmailExtractionLogs` | une ligne par mail traité | idem |
+
+Rien n'est critique à l'échelle d'un an sur un Pi. Mais c'est une base **mutualisée** avec d'autres projets et Miniflux, sur un SSD partagé, et personne ne surveille sa taille — le risque n'est pas LoreAI qui grossit, c'est LoreAI qui gêne un voisin.
+
+### F12 🟠 — Le signal le plus précieux du projet est capté puis jeté
+
+C'est le constat le plus important de cette revue, et le seul qui parle de valeur plutôt que de dette.
+
+`ReconciliationJob` (L3, lot 6) re-lit les articles suivis chez Raindrop et détecte que **l'humain a modifié les tags, déplacé l'article, ou l'a supprimé**. C'est littéralement une correction de la classification automatique, produite gratuitement par l'usage normal.
+
+Ce signal sert aujourd'hui à trois choses : marquer l'article comme « traité », détecter les liens cassés, déclencher des relances. **Il ne sert jamais à améliorer la classification suivante.** Le prompt reconstruit la taxonomie à chaque cycle (ADR 0007), mais ne sait rien de ses propres erreurs passées : si tous les articles rangés dans « X » par le modèle finissent déplacés à la main vers « Y », le modèle recommencera indéfiniment.
+
+Le projet a construit une boucle de retour complète… et ne l'a pas refermée.
+
+### F13 🟡 — Un seul webhook Discord porte cinq notifieurs
+
+`DiscordNotifier` (alerte immédiate), `DiscordCycleReportNotifier`, `DiscordWeeklyDigestNotifier`, `DiscordReportNotifier` (pièce jointe `.md`), `DiscordReminderNotifier`, `DiscordWatchDigestNotifier` — six implémentations, une seule `Discord__WebhookUrl`.
+
+Tout arrive donc dans le même salon, sans hiérarchie : une alerte qui demande une action et un digest hebdomadaire de 34 articles périmés ont la même présence visuelle. C'est ce qui a rendu [#64](https://github.com/slucky31/LoreAI/issues/64) inévitable — le canal n'est pas bruyant à cause d'un notifieur en trop, il l'est parce qu'il n'y a **qu'un** canal.
+
+### F14 🟡 — La veille laisse Miniflux se remplir indéfiniment
+
+[#98](https://github.com/slucky31/LoreAI/issues/98), bien instruit. À noter comme conséquence de conception : l'invariant « une source Feed n'est jamais réécrite » (ADR 0012) a été posé pour une catégorie de **lecture humaine**, où il est juste. Appliqué à une catégorie de **veille automatique** que personne ne lit, il produit exactement l'effet inverse de son intention : du bruit accumulé sans propriétaire.
+
+### F15 🟡 — `CLAUDE.md` décrit du code qui n'existe pas
+
+`CLAUDE.md` cite `StartupInfo` comme exemple de code partagé à réutiliser depuis `LoreAI.Infrastructure`. **Aucune occurrence de `StartupInfo` dans `src/`.** La consigne (« ne jamais dupliquer les helpers ») reste bonne ; son exemple est faux, et c'est précisément le genre de détail qui fait perdre du temps à un agent qui cherche la classe avant de comprendre qu'elle n'existe pas. À rapprocher de #65, qui demande justement d'écrire cette journalisation de démarrage.
+
+---
+
+## Ce que je propose d'ajouter
+
+Cotation homogène avec la roadmap : **V** = valeur, **E** = effort, sur 3. Le lotissement est dans [`roadmap-phase-3.md`](roadmap-phase-3.md).
+
+### Corriger la trajectoire
+
+| # | Proposition | V | E | Pourquoi |
+|---|---|---|---|---|
+| **O7** | **Sauvegarde réelle** — `pg_dump` planifié + rotation, et sauvegarde chiffrée du `.env` hors du Pi | 3 | 1 | F9. Le seul risque non rattrapable du projet |
+| **O8** | **Garde-fou budget dur** — table `LlmCalls` unifiée (job, modèle, tokens in/out/cache, coût), `ILlmBudgetGuard` consulté **avant** chaque appel, coupure des jobs LLM + une alerte au franchissement | 3 | 2 | F2. Transforme S6 d'un constat hebdomadaire en une limite. Unifie au passage les trois sources de mesure éclatées |
+| **O9** | **Limiteur de débit Raindrop partagé** — au niveau de `RaindropClient`, pas d'un job | 2 | 2 | F10. Un seul token, six appelants, des crons qui se croisent |
+| **O10** | **Journal d'identité au démarrage** ([#65](https://github.com/slucky31/LoreAI/issues/65)) — version, runtime, hôte, **et la liste des jobs réellement planifiés avec leur cron** | 3 | 1 | F1 + F15. Rend l'état de configuration lisible dans les logs, au lieu de dépendre d'un `.env` non versionné |
+| **O11** | **Healthcheck MCP** ([#68](https://github.com/slucky31/LoreAI/issues/68)) | 2 | 1 | F1. Le seul conteneur applicatif sans sonde |
+| **O12** | **Renovate débloqué** ([#40](https://github.com/slucky31/LoreAI/issues/40)) | 2 | 1 | F8. Une virgule |
+| **N6** | **Rétention** — purge glissante de `CycleRuns`, `WatchEvaluationLogs`, `EmailExtractionLogs` ; `ClassificationRawResponse` réduit au bloc `usage` au-delà de 90 jours | 1 | 1 | F11. Base mutualisée, voisins à respecter |
+
+### Refermer la boucle et exploiter le corpus
+
+| # | Proposition | V | E | Pourquoi |
+|---|---|---|---|---|
+| **L7** | **Apprentissage des corrections humaines** — mesurer le taux de correction (article déplacé/retagué après classification) par collection, puis injecter les N corrections récentes comme exemples dans le prompt de classification | 3 | 2 | F12. Le seul mécanisme qui rend l'outil meilleur avec le temps. Les données existent déjà (`ReconciliationJob`), rien à collecter |
+| **S10** | **Exploitation des surlignages** — outil MCP `get_highlights`, injection dans la revue mensuelle, « ce que tu as surligné sur X » | 3 | 1 | F4. Donnée déjà stockée, jugement humain explicite, zéro collecte à ajouter |
+| **S11** | **Expansion de requête avant embeddings** — la recherche est en `tsvector` français ; elle échoue sur la synonymie et sur le mélange FR/EN (« veille » ≠ « monitoring »). Un appel LLM court qui étend la requête coûte moins qu'un ré-embedding du corpus | 2 | 1 | À mesurer **avant** d'ouvrir `pgvector` : si l'expansion suffit, l'embedding devient inutile |
+| **S12** | **Export automatisé vers Obsidian** — variante 2 du pont, jamais écrite : un CLI qui interroge le MCP et écrit les `.md` du vault, déclenché côté PC | 2 | 2 | S7/S8 existent en outils MCP, mais restent manuels — donc peu utilisés |
+| **C6** | **Newsletters Gmail → Raindrop sous seuil** ([#94](https://github.com/slucky31/LoreAI/issues/94)) | 2 | 2 | Décidé en session : création seulement si la collection matche **et** que le signal est fort |
+
+### Ce que je ne recommande pas
+
+Autant fermer ces pistes explicitement, elles reviendront sinon.
+
+- **Un outil MCP `ask_corpus` / du RAG côté serveur.** Claude Code fait déjà le RAG côté client avec `search_items` + `get_item`. Ajouter un LLM dans le MCP, c'est payer deux fois et perdre le contrôle du contexte.
+- **Les embeddings `pgvector` maintenant.** Coût récurrent de génération sur 1 369 items + chaque nouvel item, pour un gain non démontré. S11 d'abord, mesure ensuite.
+- **Un conteneur `autoheal`.** La question traîne depuis #35. Sur trois mois d'exploitation, aucun blocage nécessitant un redémarrage automatique n'a été rapporté. Sans fréquence observée, c'est de la complexité spéculative — `CycleRuns` existe désormais pour la mesurer, il suffit de la lire dans six mois.
+- **Changer de fournisseur LLM.** L'arbitrage de la roadmap tient intégralement : quelques euros économisés contre la perte du tool-use forcé sur lequel repose toute la fiabilité.
+- **Le mode headless via l'abonnement Claude.** Enjeu de quelques euros, changement de nature du projet, conditions d'usage non vérifiées. À laisser en question ouverte, pas à loter.

--- a/docs/etat-des-lieux.md
+++ b/docs/etat-des-lieux.md
@@ -1,10 +1,10 @@
 # État des lieux
 
 > Fichier court, **réécrit et jamais complété**. Il répond à une seule question : *où on en est, là, maintenant.*
-> L'historique est dans `git log` et les Releases. La cible est dans [`roadmap.md`](roadmap.md). Les décisions sont dans [`adr/`](adr/).
-> Le suivi des lots est dans les [issues #41 à #51](https://github.com/slucky31/LoreAI/issues?q=is%3Aissue+milestone%3A*).
+> L'historique est dans `git log` et les Releases. La cible est dans [`roadmap-phase-3.md`](roadmap-phase-3.md) (phases 1-2 : [`roadmap.md`](roadmap.md)). Les décisions sont dans [`adr/`](adr/).
+> Ce qui ne va pas, avec les preuves : [`critique-fonctionnelle.md`](critique-fonctionnelle.md). Ce qui n'a jamais été vérifié en conditions réelles : [`reste-a-tester.md`](reste-a-tester.md).
 
-**Dernière mise à jour :** 2026-08-30 · **Version publiée :** 0.20.0 (#93 mergée)
+**Dernière mise à jour :** 2026-08-30 · **Version publiée :** 0.20.0
 
 ---
 
@@ -12,49 +12,64 @@
 
 | | |
 |---|---|
-| **Lot en cours** | **Lot 9 livré** ([#50](https://github.com/slucky31/LoreAI/issues/50), PR [#93](https://github.com/slucky31/LoreAI/pull/93)) : veille automatique sur sujets. **Design revu en session** après retour utilisateur sur le premier jet (alerte Discord détaillée, sujets en config statique) — chaque sujet a désormais sa propre collection Raindrop et sa propre catégorie Miniflux, provisionnées par la commande `--add-watch-topic --name=... --description=...` (persistées dans `WatchTopics`, curseur par sujet). Un article jugé pertinent et nouveau par le LLM est **créé directement dans Raindrop** (tag `veille` + tags proposés) — seul cas du projet où une source non-Raindrop crée du contenu dans Raindrop (jamais de modification d'un item existant, ADR 0012 intact). Plus de notif par article : un résumé groupé part sur Discord une fois par exécution. Désactivé par défaut (`Worker__TopicWatchEnabled=false`). 431/431 tests verts sur `main`. |
-| **Prochain geste** | Sur `mcm8` : (1) activer `Worker__TopicWatchEnabled=true`, (2) provisionner un premier sujet via `docker compose run --rm loreai-worker dotnet LoreAI.Worker.dll --add-watch-topic --name=... --description=...` (voir `docs/deploiement-raspberry-pi.md` §13), (3) ajouter les flux RSS de recherche dans la catégorie Miniflux créée. Phase 2 quasi close : reste **Lot 10 — déduplication inter-sources** ([#51](https://github.com/slucky31/LoreAI/issues/51)). |
-| **Dernière décision** | **Écriture Raindrop pour la veille validée explicitement en session (2026-08-30)**, en remplacement du design initial. Discuté en même temps : réinjecter aussi les newsletters Gmail (lot 8) dans des collections Raindrop — jugé hors scope pour ce lot, tracké séparément dans l'issue [#94](https://github.com/slucky31/LoreAI/issues/94) (questions de conception à trancher : seuil de création, `Feed` concerné ou non). |
-| **Bloqué par** | Rien. Le Pi (`mcm8`) est en ligne. |
+| **Lot en cours** | **Aucun.** Les lots 0 → 9 sont livrés : la roadmap des phases 1 et 2 est épuisée, hors lot 10 (déduplication, [#51](https://github.com/slucky31/LoreAI/issues/51)). Une revue fonctionnelle complète a été faite le 2026-08-30 ([`critique-fonctionnelle.md`](critique-fonctionnelle.md)) et a produit une **phase 3** ([`roadmap-phase-3.md`](roadmap-phase-3.md)) : lots 11 (exploitation), 12 (coût), 13 (écritures externes), puis 10 (dédup), 14 (boucle de retour), 15 (second cerveau). |
+| **Prochain geste** | Ouvrir le **lot 11 — Reprendre la main sur l'exploitation** : sauvegarde `pg_dump` + `.env` chiffré ([#37](https://github.com/slucky31/LoreAI/issues/37)), journal d'identité au démarrage étendu aux jobs planifiés ([#65](https://github.com/slucky31/LoreAI/issues/65)), healthcheck MCP ([#68](https://github.com/slucky31/LoreAI/issues/68)), Renovate débloqué ([#40](https://github.com/slucky31/LoreAI/issues/40)), logs `--add-watch-topic` ([#97](https://github.com/slucky31/LoreAI/issues/97)). En même temps : fermer les 5 issues livrées (#31, #35, #71, #73, #75) et les 3 périmées (#33, #36, #39). |
+| **Dernières décisions** (2026-08-30) | **D8** budget LLM 10 €/mois **avec garde-fou dur** dans le code (lot 12). **D9** newsletters Gmail réinjectées dans Raindrop **sous seuil** ([#94](https://github.com/slucky31/LoreAI/issues/94), lot 13). **D10** l'alerte Discord immédiate `ATester`/`Haute` est **retirée** ([#64](https://github.com/slucky31/LoreAI/issues/64), lot 12). **D11** la classification des flux RSS personnels est **retirée** ([#99](https://github.com/slucky31/LoreAI/issues/99), lot 12) — Miniflux reste lecteur humain + moteur de la veille. Détail dans [`roadmap-phase-3.md`](roadmap-phase-3.md#décisions-actées-session-du-2026-08-30). |
+| **À valider** | La règle **« un lot n'est fini que s'il est actif en production »** — proposée pour fermer l'écart livré/actif (4 des 6 derniers lots sont désactivés par défaut, état réel inconnu). Elle ralentit délibérément la livraison. |
+| **Bloqué par** | Rien. Le Pi (`mcm8`) est en ligne, le corpus est indexé (1 369 items, index frais du 2026-08-30 12:26 UTC). |
 
 ## Ce qui tourne aujourd'hui
 
-**Sur `main` :** le worker classe la collection « Non trié » toutes les 15 min (Claude Haiku, tool-use forcé), applique tags et déplacements dans Raindrop, alerte sur Discord les articles `ATester` / `Haute`, et envoie un compte-rendu Discord à la fin de chaque cycle ayant traité au moins un article. Plus d'email : le canal a été retiré (D3, ADR 0013). Persistance PostgreSQL (instance mutualisée sur `mcm8`, EF Core), modèle `Item` générique multi-sources, journal `CycleRuns` et healthcheck Docker (lot 0). Serveur MCP en lecture seule (lot 3, ADR 0014) avec recherche plein texte (Q2, lot 5). `LibraryIndexingJob` (hebdomadaire) indexe en lecture seule toute la bibliothèque Raindrop déjà triée par l'utilisateur (lot 1) ; `WeeklyInsightsJob` (hebdomadaire, juste après) lit cet index et envoie un digest Discord natif (embeds, doublons, tags à nettoyer, collections déséquilibrées, tendances, coût LLM) — zéro appel LLM, zéro écriture (lot 2, revu au lot 7/O6). Connecteurs Gmail (lot 8) et RSS/Miniflux (lot 7) écrits et testés ; `ReadingQueueTaggingJob` (L5, lot 8) écrit et testé, désactivé par défaut. Veille automatique (lot 9, #50) écrite et testée, désactivée par défaut — voir « Prochain geste » pour l'activer. Déploiement par image `ghcr.io` multi-arch, le Pi ne fait que `pull`.
+**Sur `main` :** le worker classe « Non trié » toutes les 15 min (Claude Haiku, tool-use forcé), applique tags et déplacements dans Raindrop, et envoie un compte-rendu Discord en fin de cycle dès qu'au moins un article a été traité. Persistance PostgreSQL mutualisée (EF Core, ADR 0009/0011), modèle `Item` générique multi-sources (ADR 0012), journal `CycleRuns` et healthcheck Docker. Serveur MCP en lecture seule (ADR 0014), 11 outils, recherche plein texte `tsvector`. Jobs planifiés : indexation de bibliothèque (hebdo), insights hebdomadaires (embeds Discord), revue mensuelle narrative (pièce jointe `.md`), réconciliation (quotidienne). Connecteurs Gmail et RSS/Miniflux, file de lecture taguée et veille sur sujets : **écrits, testés, désactivés par défaut**. Déploiement par image `ghcr.io` multi-arch, le Pi ne fait que `pull`.
 
-**Réellement en production sur `mcm8` :** l'état exact des flags d'activation (`Worker__FeedIngestionEnabled`, `Worker__EmailIngestionEnabled`, `Worker__ReadingQueueTaggingEnabled`, `Worker__TopicWatchEnabled`) n'a pas été revérifié depuis la session du 2026-08-29 — se fier au `.env` réel sur `mcm8`, pas à cette ligne.
+**Réellement actif sur `mcm8` : partiellement vérifié.** `Worker__EmailIngestionEnabled` **est actif** (constaté le 2026-08-30 : une entrée `sourceType = Newsletter` du jour même dans la file de lecture). Les trois autres flags (`Worker__FeedIngestionEnabled`, `Worker__ReadingQueueTaggingEnabled`, `Worker__TopicWatchEnabled`) restent inconnus — voir [`reste-a-tester.md`](reste-a-tester.md#-flags-dactivation--les-trois-inconnues-restantes) pour les trois requêtes qui les lèvent. C'est le trou que ferme le lot 11 ([#65](https://github.com/slucky31/LoreAI/issues/65) étendu au listing des jobs planifiés) — d'ici là, **se fier au `.env` sur `mcm8`, jamais à cette ligne**.
 
-Reste de la roadmap non implémenté : déduplication inter-sources (lot 10, #51).
+## Les trois choses qui doivent changer en premier
+
+Issues de la revue du 2026-08-30, par ordre de gravité — le détail et les preuves sont dans [`critique-fonctionnelle.md`](critique-fonctionnelle.md).
+
+1. **Il n'y a aucune sauvegarde.** Ni `pg_dump` de la base (1 369 items, historique de classification, curseurs — dont la perte déclenche un backfill LLM), ni copie du `.env` de `mcm8` (7 secrets qui n'existent nulle part ailleurs, dont un refresh token OAuth Google). Risque le plus élevé du projet, devant le coût.
+2. **Le coût LLM n'est mesuré qu'a posteriori, une fois par semaine.** Aucun code ne peut refuser un appel parce que le budget est dépassé — c'est ce qui a laissé passer le volet RSS du lot 7 à ~36 $/mois estimés (D11/#99), découvert par lecture de code.
+3. **Renovate est bloqué** par une virgule manquante dans `renovate.json:5` : aucune mise à jour de dépendance ne passe. Correctif d'un caractère.
 
 ## Décisions actées, non encore appliquées
 
 | | Décision | Où c'est écrit |
 |---|---|---|
-| D1 | Hub multi-sources (Raindrop + Gmail + RSS) | [roadmap](roadmap.md), [ADR 0012](adr/0012-modele-item-generique-multi-sources.md) ✅ — modèle `Item`/`ISourceIngester` et les trois connecteurs écrits ; Gmail reste à activer en production, Miniflux en cours d'activation (voir tableau ci-dessus) |
-| D2 | Réseau privé strict — LAN **ou tailnet**, jamais d'exposition publique | [ADR 0010](adr/0010-topologie-reseau-tailscale.md) ✅ |
-| D4 | Le vault Obsidian n'est pas visible du Pi | [roadmap](roadmap.md) |
-| D5 | On récupère le contenu réel des articles | [roadmap](roadmap.md) |
+| D1 | Hub multi-sources (Raindrop + Gmail + RSS) | [roadmap](roadmap.md), [ADR 0012](adr/0012-modele-item-generique-multi-sources.md) ✅ — les trois connecteurs sont écrits ; le volet classification RSS est retiré par D11 |
+| D2 | Réseau privé strict — LAN **ou** tailnet, jamais d'exposition publique | [ADR 0010](adr/0010-topologie-reseau-tailscale.md) ✅ |
+| D4 | Le vault Obsidian n'est pas visible du Pi | [roadmap](roadmap.md) — conditionne S12 (export côté PC, lot 15) |
+| D5 | On récupère le contenu réel des articles | [roadmap](roadmap.md) ✅ (lot 4) |
 | D6 | Modèle de synthèse non tranché | [roadmap](roadmap.md) |
 | D7 | PostgreSQL mutualisé, EF Core (pas Dapper) | [ADR 0009](adr/0009-postgresql-mutualise-sur-le-pi.md) ✅, [ADR 0011](adr/0011-ef-core-remplace-dapper.md) ✅ |
+| D8 | Budget LLM 10 €/mois avec garde-fou dur | [phase 3](roadmap-phase-3.md) — lot 12 |
+| D9 | Newsletters Gmail → Raindrop sous seuil | [phase 3](roadmap-phase-3.md), [#94](https://github.com/slucky31/LoreAI/issues/94) — lot 13 |
+| D10 | Retrait de l'alerte Discord immédiate | [phase 3](roadmap-phase-3.md), [#64](https://github.com/slucky31/LoreAI/issues/64) — lot 12 |
+| D11 | Retrait de la classification des flux RSS personnels | [phase 3](roadmap-phase-3.md), [#99](https://github.com/slucky31/LoreAI/issues/99) — lot 12 |
 
 ## À trancher par une mesure, pas par un débat
 
-- ~~**Spike OpenClaw**~~ — **tranché, 2026-08-23.** OpenClaw est un *client* MCP (se connecte à des serveurs existants), pas un serveur — il ne peut pas remplacer le MCP du lot 3, qui doit être écrit quoi qu'il arrive. Détail dans [roadmap.md](roadmap.md#un-outil-existe-t-il-déjà--spike-fait-2026-08-23--le-lot-3-reste-nécessaire).
-- **Cache de prompt** ([#34](https://github.com/slucky31/LoreAI/issues/34)) — 30 min de mesure, à faire au lot 4. A priori sans effet au volume actuel, décisif au backfill.
-- ~~**Docker sur le poste de travail**~~ — **tranché.** Le Shadow PC ne peut pas faire tourner Docker (`HCS_E_HYPERV_NOT_INSTALLED` : pas de virtualisation imbriquée). Le développement se fait donc depuis un environnement qui en dispose, et les tests utilisent `Testcontainers.PostgreSql`.
+- **Cache de prompt** ([#34](https://github.com/slucky31/LoreAI/issues/34)) — la mesure de 30 min annoncée depuis la phase 1 n'a jamais été faite. Elle devient une simple lecture une fois la table `LlmCalls` en place (lot 12). **À trancher et fermer dans ce lot.**
+- **Utilité du lot 10 (déduplication)** — combien de doublons inter-sources le rapport hebdomadaire remonte-t-il réellement ? Avec D11, il ne reste que trois producteurs d'items classés.
+- **`important` / `broken`** — 0 sur 1 369 items. Retirer l'analyseur de liens morts, ou sonder réellement les URLs (le crawler que N3 voulait éviter) ?
+- **`pgvector`** — conditionné à l'échec **mesuré** de l'expansion de requête (S11, lot 15), jamais ouvert par anticipation.
+- **Autoheal** — laissé sans ticket : aucun blocage observé en trois mois. `CycleRuns` existe désormais pour le mesurer, à reconsidérer sur données.
+- ~~**Spike OpenClaw**~~ — tranché 2026-08-23 : c'est un *client* MCP, pas un serveur. Détail dans [roadmap.md](roadmap.md#un-outil-existe-t-il-déjà--spike-fait-2026-08-23--le-lot-3-reste-nécessaire).
+- ~~**Docker sur le poste de travail**~~ — tranché : le Shadow PC ne peut pas faire tourner Docker (`HCS_E_HYPERV_NOT_INSTALLED`).
 
 ## Environnement, à ne pas re-découvrir
 
-- **Deux postes.** `shadow-p9t9qc7h` (**Shadow PC**, Windows hébergé dans le cloud) et **`afl-it-ndu`**, la machine de développement Docker-capable — dessus, le travail se fait dans la distro WSL2 **`Ubuntu-perso`**. Aucun des deux postes n'est sur le LAN domestique — c'est ce constat qui a invalidé la formulation d'origine de D2, voir [ADR 0010](adr/0010-topologie-reseau-tailscale.md).
+- **Deux postes.** `shadow-p9t9qc7h` (**Shadow PC**, Windows hébergé dans le cloud) et **`afl-it-ndu`**, la machine de développement Docker-capable — dessus, le travail se fait dans la distro WSL2 **`Ubuntu-perso`**. Aucun des deux n'est sur le LAN domestique — c'est ce constat qui a invalidé la formulation d'origine de D2, voir [ADR 0010](adr/0010-topologie-reseau-tailscale.md).
 - **Le développement et les tests se font depuis `Ubuntu-perso` (sur `afl-it-ndu`)**, puisque `Testcontainers.PostgreSql` exige un daemon Docker. Le Shadow reste utilisable pour le reste : lecture, rédaction, `git`, appels d'API.
 - **Le Shadow ne pourra jamais exécuter la suite de tests** : sa plateforme n'expose pas la virtualisation imbriquée (`HCS_E_HYPERV_NOT_INSTALLED`), donc ni WSL2, ni Hyper-V, ni Docker Desktop. Inutile de réessayer.
 - **`Ubuntu-perso` a eu besoin d'une mise en route, désormais faite mais pas automatisée — utile si un jour reprovisionnée :**
-  1. Docker Desktop (Windows) tournait déjà sur `afl-it-ndu` mais son intégration WSL doit être activée **par distro** — `Settings → Resources → WSL Integration`, cocher `Ubuntu-perso`, puis rouvrir un terminal (le shell déjà ouvert ne voit pas le changement). *(Une alternative sans Docker Desktop — Docker CE directement dans la distro, ou Rancher Desktop/Podman — évite la question de licence, mais n'a pas été le chemin pris ici.)*
+  1. Docker Desktop (Windows) tournait déjà sur `afl-it-ndu` mais son intégration WSL doit être activée **par distro** — `Settings → Resources → WSL Integration`, cocher `Ubuntu-perso`, puis rouvrir un terminal (le shell déjà ouvert ne voit pas le changement).
   2. Le SDK .NET n'y était **pas préinstallé**. Installé via `dotnet-install.sh --version <celle de global.json>` dans `~/.dotnet`, ajouté au `PATH`.
-  3. `dotnet` plante avec `Couldn't find a valid ICU package` (pas de `libicu`, et `sudo` indisponible sans terminal interactif dans cette session). Contournement : `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` — c'est déjà le mode du conteneur de production (cf. commentaire dans `Program.cs`), donc pas un hack propre au dev.
+  3. `dotnet` plante avec `Couldn't find a valid ICU package` (pas de `libicu`). Contournement : `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` — c'est déjà le mode du conteneur de production, donc pas un hack propre au dev.
   4. Outillage EF Core : manifeste d'outils local (`.config/dotnet-tools.json`, `dotnet-ef` épinglé) — `dotnet tool restore` avant `dotnet ef migrations add ...`.
-- **Tailscale** relie les postes et le Pi. Tailnet `piranha-pollux.ts.net`, le Pi est le nœud **`mcm8`** — donc `mcm8.piranha-pollux.ts.net`. C'est cette adresse que vise le MCP du lot 3, jamais `raspberrypi.local`. Un second nœud Linux, `proxy`, existe (rôle non documenté ici). Le CLI `tailscale` n'est pas installé dans `Ubuntu-perso` ; utiliser le binaire Windows via l'interop WSL : `"/mnt/c/Program Files/Tailscale/tailscale.exe" status`.
-- ⚠️ **Piège vécu, à ne pas repayer** : Tailscale fait expirer les clés de nœud au bout de quelques mois. Le nœud quitte alors le tailnet **sans panne et sans message** — c'est ce qui avait rendu `mcm8` et `proxy` invisibles le 2026-08-04. **`mcm8` est de nouveau en ligne** (vérifié en session), mais désactiver l'expiration de clé sur tout nœud serveur, dans la console d'admin Tailscale, reste à faire pour ne pas revivre l'épisode.
-- ⚠️ **Piège vécu au provisionnement Postgres (PR 1)** : un client SQL graphique (DBeaver...) garde un script lié à la base active au moment de son ouverture — un `GRANT ... ON SCHEMA public` lancé dans un onglet resté sur `postgres` s'applique silencieusement au mauvais `public` (0 erreur, mais aucun effet sur `loreai`). Vérifier `SELECT current_database();` avant tout GRANT. Cause du même effet observé deux fois : PostgreSQL 15+ retire `CREATE` à `PUBLIC` sur le schéma `public` par défaut — sans le `GRANT` explicite (déjà dans `docs/deploiement-raspberry-pi.md` §3), EF Core échoue avec `permission denied for schema public` à la première migration.
+- **Tailscale** relie les postes et le Pi. Tailnet `piranha-pollux.ts.net`, le Pi est le nœud **`mcm8`** — donc `mcm8.piranha-pollux.ts.net`. C'est cette adresse que vise le MCP, jamais `raspberrypi.local`. Le CLI `tailscale` n'est pas installé dans `Ubuntu-perso` ; utiliser le binaire Windows via l'interop WSL : `"/mnt/c/Program Files/Tailscale/tailscale.exe" status`.
+- ⚠️ **Piège vécu, à ne pas repayer** : Tailscale fait expirer les clés de nœud au bout de quelques mois. Le nœud quitte alors le tailnet **sans panne et sans message** — c'est ce qui avait rendu `mcm8` et `proxy` invisibles le 2026-08-04. **`mcm8` est en ligne**, mais désactiver l'expiration de clé sur tout nœud serveur, dans la console d'admin Tailscale, **reste à faire**.
+- ⚠️ **Piège vécu au provisionnement Postgres** : un client SQL graphique garde un script lié à la base active au moment de son ouverture — un `GRANT ... ON SCHEMA public` lancé dans un onglet resté sur `postgres` s'applique silencieusement au mauvais `public`. Vérifier `SELECT current_database();` avant tout GRANT. PostgreSQL 15+ retire `CREATE` à `PUBLIC` sur le schéma `public` par défaut — sans le `GRANT` explicite (déjà dans `docs/deploiement-raspberry-pi.md` §3), EF Core échoue avec `permission denied for schema public`.
 
 ## Comment tenir ce fichier
 

--- a/docs/reste-a-tester.md
+++ b/docs/reste-a-tester.md
@@ -1,0 +1,176 @@
+# Ce qu'il reste à tester
+
+> Établi le **2026-08-30**, à partir de la [revue fonctionnelle](critique-fonctionnelle.md) et d'une vérification réelle sur la production (`mcm8`, v0.20.0).
+> Un lot n'est pas vérifié parce que ses tests unitaires passent : `dotnet test` prouve que le code fait ce qu'on a écrit, pas que la fonctionnalité produit quelque chose d'utile en conditions réelles.
+> Précédent du même genre : commit `9802cd5`, « vérification partielle du lot 5 en production ».
+
+## Comment tenir ce fichier
+
+Une ligne se ferme par **une observation datée**, jamais par une lecture de code : *« vérifié le 2026-09-01 : le rapport est arrivé sur Discord, 4 sections, aucun repli »*. Une ligne dont le critère de réussite n'est pas écrit n'est pas testable — l'écrire est la moitié du travail.
+
+Légende : ✅ vérifié en production · ⏳ en attente d'un déclenchement · ❓ jamais observé · 🔴 anomalie trouvée en vérifiant.
+
+---
+
+## Vérifié le 2026-08-30
+
+Fait pendant la revue, via le serveur MCP de production et les logs.
+
+| Élément | Observation |
+|---|---|
+| ✅ **Corpus indexé** (lot 1) | `stats` → 1 369 items, index frais de moins de 4 h (`2026-08-30T12:26Z`). L'indexation hebdomadaire tourne |
+| ✅ **`search_items`, `find_similar`, `export_item`** (Q2, S5, S8) | Déjà vérifiés au lot 5 (commit `9802cd5`, 1 333 items) — toujours cohérents |
+| ✅ **`stats`** (Q1) | Répond, valeurs plausibles |
+| ✅ **`catalog_tools`** (S7) | **Nouveau** : 21 outils catalogués entre le 2026-08-24 et le 2026-08-30. C'était le point resté « à vérifier » du lot 5 — il est fermé |
+| ✅ **`reading_queue`** (L1) | **Nouveau** : file scorée non vide, tri décroissant cohérent, `sourceType` renseigné |
+| ✅ **Ingestion Gmail active en production** (lot 8) | Déduit d'une entrée `sourceType: "Newsletter"` datée du 2026-08-30 09:00 dans la file de lecture. **Un des quatre flags inconnus est donc levé** : `Worker__EmailIngestionEnabled=true` |
+| ✅ **Logs en heure de Paris** (O4, #71) | Ligne de log de `--add-watch-topic` du 2026-08-30 horodatée `[15:38:57]`, soit CEST et non UTC |
+| ✅ **`--add-watch-topic`** (lot 9) | Sujet `enterprise-brain` provisionné sur `mcm8` : collection Raindrop 74518640 + catégorie Miniflux 2 créées |
+| ✅ **Péremption** (N4) | Observée au lot 7 : section « 34 articles périmés » dans le rapport hebdomadaire — c'est même ce volume qui a motivé #78 |
+
+## 🔴 Anomalies trouvées en vérifiant
+
+Trois défauts que seule l'observation de données réelles pouvait révéler. Aucun n'a de ticket.
+
+### A1 — Un lien de désinscription est classé « Priorité Haute » et remonte en 2ᵉ position de la file de lecture
+
+Entrée réelle de `reading_queue`, `sourceType = Newsletter`, capturée le 2026-08-30 :
+
+```
+Titre : "Claude Code for .NET Developers - Free Course"
+URL   : https://dd573b8f.click.kit-mail3.com/.../aHR0cHM6Ly9hcHAua2l0LmNvbS9wcmVmZXJlbmNlcy1jb25maXJtZWQ=
+```
+
+Le segment final est du base64 : il décode en **`https://app.kit.com/preferences-confirmed`** — une page de confirmation de préférences d'abonnement, pas un article.
+
+`EmailLinkNoiseFilter` exclut bien les motifs `unsubscribe` / `preferences`, mais il les cherche **en clair dans l'URL**. Ici le motif est encodé en base64 à l'intérieur d'un redirecteur de tracking, donc invisible au filtre — et l'extracteur LLM, qui ne voit que l'ancre (« Free Course »), n'avait aucune raison de le rejeter. Le lien a ensuite été classé `Priority = Haute` et occupe la 2ᵉ place d'une file de lecture censée être la meilleure recommandation de la semaine.
+
+À vérifier avant de corriger : **combien d'entrées `Newsletter` du corpus sont dans ce cas ?** La correction (décoder les segments base64 des URLs avant d'appliquer le filtre) est triviale, mais son intérêt dépend du volume.
+
+### A2 — Le temps de lecture estimé vaut 1 minute pour toute la tête de file
+
+Les 5 premières entrées de `reading_queue` ont toutes `estimatedMinutes: 1`. Quatre d'entre elles sont des liens raccourcis `lnkd.in`.
+
+Deux conséquences, qui se cumulent :
+
+- **L2 ne produit rien d'exploitable** : le nombre de mots vient de `ContentText`, et la récupération de contenu échoue ou ne rapporte quasi rien sur ces domaines (redirection LinkedIn, contenu majoritairement rendu en JS). Le best-effort fonctionne comme prévu — l'article n'est pas perdu — mais la donnée qui en sort est constante.
+- **Le score L1 perd un de ses trois facteurs** : « priorité × fraîcheur × temps de lecture » devient de fait « priorité × fraîcheur », puisque le troisième terme est identique partout. Le classement n'est pas faux, il est simplement moins informé qu'annoncé.
+
+À mesurer : le taux réel de `ContentStatus` en échec par domaine. C'est une requête, pas un chantier.
+
+### A3 — Le catalogue d'outils est en écriture seule
+
+Les 21 outils catalogués ont **tous** `status = "À évaluer"` et `relatedArticleCount = 1`. Aucun n'a jamais changé d'état, aucun n'a jamais été rencontré deux fois.
+
+Le champ `status` a donc un cycle de vie théorique que rien ne fait avancer : ni le pipeline (il n'y a pas d'événement « j'ai testé cet outil »), ni un outil MCP en écriture (Q3 n'a jamais été livré). S7 promettait « nom, catégorie, statut d'évaluation, articles liés, **verdict** » — la moitié de cette promesse est un champ mort.
+
+Décision à prendre, pas un bug à corriger : soit retirer le champ, soit livrer le moyen de le renseigner (Q3, un outil MCP en écriture, seul cas où il serait justifié).
+
+---
+
+## Vérifications en attente — production
+
+### ⏳ S4 — Revue mensuelle narrative (lot 5)
+
+Le seul livrable du projet qui n'a **jamais tourné**. Premier passage cron prévu le **2026-09-01 05:00 UTC**.
+
+- **Ne pas attendre le cron** : `--run-monthly-review` existe depuis le lot 6 (O5, #75) précisément pour ça.
+- **Critère** : un fichier `.md` arrive en pièce jointe sur Discord, avec une section par thème, un narratif cohérent et aucun repli de parsing dans les logs.
+- **À surveiller en même temps** : le coût. C'est l'appel LLM le plus lourd du projet (~30 000 tokens d'entrée par thème). C'est l'occasion de mesurer avant que le garde-fou du lot 12 n'existe.
+
+### ⏳ S7 — `tool_card` (lot 5)
+
+`catalog_tools` est vérifié ; la génération de fiche ne l'est pas.
+
+- **Geste** : `tool_card` sur un outil du catalogue (ex. `Fabric`, `browser-use`).
+- **Critère** : un Markdown complet, frontmatter valide, articles liés présents, directement écrivable dans le vault.
+
+### ❓ L4 — Relances (lot 6)
+
+`DiscordReminderNotifier` existe et n'a **jamais été observé**. Il lui faut un article `ATester`/`Haute` non traité depuis 14 jours.
+
+- Le corpus en contient : la file de lecture montre des `Haute` capturés les 27 et 28 août → seuil atteignable vers le **10-11 septembre**.
+- **Critère** : un message Discord de relance, une seule fois par article, pas une répétition quotidienne à chaque passage de `ReconciliationJob`. **C'est le vrai risque à vérifier** : le job est quotidien, et rien dans son nom ne garantit que la relance ne se répète pas.
+
+### ❓ L5 — File de lecture taguée (lot 8)
+
+État du flag `Worker__ReadingQueueTaggingEnabled` sur `mcm8` : inconnu. Cron : dimanche 4h05 UTC.
+
+- **Critère de pose** : le tag `cette-semaine` apparaît dans Raindrop sur les articles de la file, **et sur eux seuls**.
+- **Critère de retrait** (le plus important, jamais observé) : à la passe suivante, les articles sortis de la file **perdent** le tag — le code le fait (`toUntag`), mais un échec y est seulement journalisé et « repris à la prochaine passe ». Un retrait qui échoue en silence produit un tag qui s'accumule semaine après semaine.
+- **Critère d'invariant** : ni la collection ni la note des articles tagués ne changent. C'est la première écriture du projet hors « Non trié » — la vérifier est le prix de la dérogation.
+
+### ❓ Lot 9 — Veille automatique
+
+Le sujet est provisionné, la chaîne complète n'a jamais tourné. Il manque deux gestes manuels :
+
+1. Ajouter les flux RSS de recherche dans la catégorie Miniflux `enterprise-brain` (via l'UI Miniflux).
+2. Passer `Worker__TopicWatchEnabled=true`, puis attendre le cron (toutes les 6 h).
+
+- **Critère** : au moins un raindrop **créé** dans la collection du sujet, portant le tag `veille` + les tags proposés, et un digest Discord groupé (un message par exécution, pas un par article).
+- **Critère négatif, tout aussi important** : aucun item existant de Raindrop n'est modifié. La veille crée, elle ne touche jamais à ce qui est déjà rangé (ADR 0012).
+- **À observer aussi** : le coût par exécution, et le taux de rejet du filtre LLM. Un sujet mal cadré peut créer beaucoup de bruit dans une vraie collection Raindrop — c'est réversible, mais fastidieux.
+
+### ❓ Flags d'activation — les trois inconnues restantes
+
+`Worker__EmailIngestionEnabled` est levé (voir plus haut). Restent :
+
+| Flag | Comment le vérifier sans SSH |
+|---|---|
+| `Worker__FeedIngestionEnabled` | `SELECT * FROM "Articles" WHERE "SourceType" = 'Feed' LIMIT 1` — sans objet après le lot 12 (D11), mais la requête conditionne le sort de l'enum `SourceType.Feed` (point ouvert de #99) |
+| `Worker__ReadingQueueTaggingEnabled` | Présence du tag `cette-semaine` dans la taxonomie Raindrop |
+| `Worker__TopicWatchEnabled` | `SELECT count(*) FROM "WatchEvaluationLogs"` |
+
+Ces trois requêtes sont un **contournement** : le vrai correctif est O10 (lot 11), qui journalise les jobs planifiés au démarrage.
+
+---
+
+## Vérifications en attente — exploitation
+
+Aucune de ces lignes n'est un test unitaire. Toutes sont des gestes sur `mcm8`, et aucune n'a jamais été faite.
+
+| # | À vérifier | Critère de réussite | Pourquoi ça compte |
+|---|---|---|---|
+| E1 | **Restauration d'une sauvegarde** | Un `pg_restore` sur une base jetable redonne un corpus complet et des curseurs cohérents | Une sauvegarde jamais restaurée n'est pas une sauvegarde. Bloqué tant que O7 (lot 11) n'existe pas |
+| E2 | **Healthcheck vu par Portainer** | Le conteneur `loreai-worker` affiche `healthy` | C'était l'objet même de #35 ; livré, jamais confirmé côté Portainer |
+| E3 | **Bascule en `unhealthy`** | Arrêter PostgreSQL, ou attendre 45 min sans cycle → le conteneur passe `unhealthy` | Un healthcheck qui ne passe jamais au rouge n'est pas un healthcheck. **Le seul test qui prouve que la sonde discrimine** |
+| E4 | **Démarrage sans la base** | Le worker démarre, journalise, réessaie — il ne meurt pas | Exigence explicite du lot 0 (« pas de `depends_on` vers une instance qu'il ne possède pas »). Jamais éprouvée en réel |
+| E5 | **Redémarrage du Pi** | Les trois conteneurs remontent dans le bon ordre, le worker retrouve ses curseurs, aucun doublon ni backfill | `restart: unless-stopped` + réseau Docker externe + base mutualisée : trois choses qui peuvent se croiser au boot |
+| E6 | **Expiration de clé Tailscale** | L'expiration est désactivée sur `mcm8` dans la console d'admin | Piège déjà vécu le 2026-08-04 : le nœud quitte le tailnet sans panne ni message. Toujours pas fait |
+| E7 | **Rate limit Raindrop sous charge croisée** | Faire coïncider réconciliation et cycle de polling → aucun 429/403 | Rafale observée le 2026-08-29 (#86). À rejouer **après** le limiteur du lot 13, sinon on ne saura pas s'il sert |
+| E8 | **`--health-check` en code de retour** | `echo $?` vaut 0 en bonne santé, 1 sinon | Testé unitairement (`HealthCheckModeTests`), jamais dans le conteneur réel |
+
+---
+
+## Trous de couverture automatisée
+
+La suite est solide — 431 tests, 63 fichiers, tous les analyseurs purs et tous les jobs couverts. Les manques listés ci-dessous sont réels mais secondaires : **aucun ne justifie de retarder un lot**, et plusieurs disparaîtront d'eux-mêmes (les tests de `FeedIngestionJob`/`MinifluxIngester` sont supprimés au lot 12 avec leur code).
+
+| Manque | Gravité | Note |
+|---|---|---|
+| `DiscordReminderNotifier` | 🟠 | Seul notifieur Discord sans test, et seul dont le comportement en production n'a jamais été observé non plus (L4 ci-dessus). Le seul manque de cette liste qui cumule les deux |
+| `WatchEvaluationLogRepository`, `EmailExtractionLogRepository` | 🟡 | Les deux tables de journal les plus récentes ; tous les autres repositories sont testés |
+| `LlmResponseTextSanitizer` | 🟡 | Couvert indirectement par les tests de parsing, jamais directement. C'est pourtant une défense contre du contenu non maîtrisé |
+| `PostgresSchemaInitializer` | 🟡 | Exécuté à chaque démarrage, jamais testé |
+| Modes CLI `--add-watch-topic`, `--run-weekly-insights`, `--run-monthly-review` | 🟡 | Seul `--health-check` a son test (`HealthCheckModeTests`). Les trois autres ne sont éprouvés qu'à la main. C'est aussi le chemin qui a produit le bug corrigé par `7b83b5f` |
+| Cohérence modèle EF ↔ migrations | 🟡 | Rien ne détecte un `DbContext` modifié sans migration générée. Un test qui échoue si `dotnet ef migrations has-pending-model-changes` est vrai coûte peu et évite une panne au démarrage en production |
+| Câblage DI de `Program.cs` | 🟡 | Aucun test ne vérifie que le conteneur résout tous les jobs. Une dépendance oubliée se découvre au démarrage sur le Pi, pas en CI |
+
+## Ce qui ne peut pas être testé depuis l'environnement de développement
+
+À rappeler pour ne pas le redécouvrir :
+
+- **Le Shadow PC n'exécutera jamais la suite de tests** (`HCS_E_HYPERV_NOT_INSTALLED` : ni WSL2, ni Hyper-V, ni Docker). Tests et migrations depuis `Ubuntu-perso` sur `afl-it-ndu` uniquement.
+- **Aucun accès SSH ou API au Pi depuis le bac à sable.** Toute vérification d'exploitation (E1 → E8) se fait par des commandes copiables fournies à l'utilisateur.
+- **Docker est requis pour `dotnet test`** (`Testcontainers.PostgreSql`) : vérifier `docker info` avant de lancer, et le signaler plutôt que de réessayer.
+
+---
+
+## Ordre suggéré
+
+1. **Maintenant, sans rien attendre** : `--run-monthly-review` (S4) et `tool_card` (S7) — deux commandes, deux lignes fermées, et une mesure de coût utile avant le lot 12.
+2. **Ce week-end** : L5 au passage du dimanche 4h05, si le flag est actif.
+3. **Vers le 10 septembre** : L4, quand le seuil de 14 jours sera atteint.
+4. **Avec le lot 11** : E1 à E5 — la sauvegarde et le healthcheck se testent au moment où on les construit, jamais après.
+5. **Après le lot 13** : E7, pour prouver que le limiteur de débit sert à quelque chose.
+6. **Quand tu veux** : les trois anomalies A1-A3, qui méritent chacune un ticket avant d'être corrigées.

--- a/docs/roadmap-phase-3.md
+++ b/docs/roadmap-phase-3.md
@@ -1,0 +1,225 @@
+# Roadmap — Phase 3 : consolider et exploiter
+
+> Écrite le **2026-08-30**, après revue complète du code, des 22 issues ouvertes et de la production.
+> Suite de [`roadmap.md`](roadmap.md), qui couvre les phases 1 et 2 (lots 0 → 9, **tous livrés**) et reste la référence pour les décisions D1-D7 et les arbitrages déjà tranchés.
+> Les constats qui motivent ce document sont dans [`critique-fonctionnelle.md`](critique-fonctionnelle.md).
+
+## Pourquoi une phase 3
+
+La phase 1 avait un objectif clair : *transformer une base en écriture seule en actif exploitable*. La phase 2 : *élargir les sources*. Les deux sont faites. Il reste un seul lot de l'ancienne carte (déduplication, [#51](https://github.com/slucky31/LoreAI/issues/51)), et le projet se retrouve sans cap.
+
+Ce n'est pas un vide : la revue fonctionnelle a mis en évidence un déséquilibre net entre **ce qui a été construit** et **ce qui est réellement exploité**.
+
+| | |
+|---|---|
+| Fonctionnalités livrées en 3 mois | 10 lots, 4 projets, ~14 700 lignes, 431 tests |
+| Fonctionnalités actives par défaut | le cycle « Non trié », l'indexation, les deux rapports, la réconciliation |
+| Fonctionnalités livrées mais désactivées | Gmail, RSS, file de lecture taguée, veille — **4 sur les 6 derniers lots** |
+| Données collectées et jamais relues | surlignages, corrections humaines, `important`/`broken` (0 sur 1 369) |
+| Sauvegardes | **aucune** |
+
+La phase 3 ne cherche donc pas à ajouter des sources ni des jobs. Elle a trois objectifs, dans cet ordre :
+
+1. **Reprendre en main l'exploitation** — savoir ce qui tourne, ne rien perdre, ne pas dériver en coût.
+2. **Refermer les boucles ouvertes** — le signal humain capté puis jeté, les données stockées puis ignorées.
+3. **Ouvrir l'usage quotidien** — le second cerveau, seule promesse de départ encore non tenue.
+
+## Décisions actées (session du 2026-08-30)
+
+Ces quatre points sont tranchés et contraignent le reste du document.
+
+| # | Décision | Conséquence |
+|---|---|---|
+| **D8** | **Budget LLM : 10 €/mois, avec garde-fou dur dans le code.** La mesure a posteriori de S6 ne suffit pas — voir F2. | Introduit une table `LlmCalls` unifiée et une interface `ILlmBudgetGuard` consultée **avant** chaque appel LLM. Au franchissement du seuil : les jobs consommateurs de LLM s'arrêtent proprement, une alerte part une seule fois, le pipeline non-LLM continue. Lot 12 |
+| **D9** | **Les newsletters Gmail classées sont réinjectées dans Raindrop, sous seuil** ([#94](https://github.com/slucky31/LoreAI/issues/94)). Création uniquement si `SuggestedCollection` correspond exactement à une collection existante **et** que `Action = ATester` ou `Priority = Haute`. | Deuxième dérogation contrôlée à « une source non-Raindrop n'écrit pas dans Raindrop » (ADR 0012), après la veille du lot 9 — toujours en **création**, jamais en modification. Tag d'origine obligatoire (`newsletter`), flag dédié `false` par défaut. `Feed` **non concerné** (voir D11). Lot 13 |
+| **D10** | **L'alerte Discord immédiate `ATester`/`Haute` est retirée** ([#64](https://github.com/slucky31/LoreAI/issues/64)). | Supprime `IImmediateNotifier`, `DiscordNotifier`, `INotificationPolicy`, `DefaultNotificationPolicy` et le compteur `Notified` de `CycleRuns`. Le filet « rien ne se perd » est désormais assuré par la file de lecture hebdomadaire (L1/L5) et le compte-rendu de cycle (O1), tous deux livrés — la justification d'origine de l'ADR 0005 ne tenait plus depuis l'ADR 0013. Lot 12 |
+| **D11** | **La classification des flux RSS personnels est retirée** ([#99](https://github.com/slucky31/LoreAI/issues/99), déjà instruite). Miniflux reste le lecteur humain et le moteur RSS de la veille. | Confirme la règle générale : **on ne branche jamais un pipeline payant sur une source non bornée sans plafond.** « Non trié » est borné par les sauvegardes humaines ; un abonnement RSS ne l'est pas. Lot 12 |
+
+### Une règle de fin de lot, à valider
+
+Proposition issue du constat F1, à confirmer avant de l'appliquer :
+
+> **Un lot n'est pas terminé tant qu'il n'est pas actif en production.** La définition de « fini » passe de *« PR mergée, tests verts, roadmap à jour »* à *« … et le flag activé sur `mcm8`, avec une observation consignée dans l'état des lieux »*.
+
+Sans cette règle, chaque lot ajoute un flag `false` de plus et l'écart livré/actif continue de croître. Avec elle, le rythme de livraison ralentit — c'est le prix, et il est assumé ou non explicitement.
+
+## Nouveaux scénarios
+
+Cotation homogène avec [`roadmap.md`](roadmap.md) : **V** = valeur, **E** = effort, sur 3. Le détail de chaque constat est dans la [critique fonctionnelle](critique-fonctionnelle.md).
+
+| # | Scénario | V | E | Constat |
+|---|---|---|---|---|
+| O7 | **Sauvegarde réelle** — `pg_dump` planifié + rotation, `.env` chiffré hors du Pi | 3 | 1 | F9 |
+| O8 | **Garde-fou budget dur** — `LlmCalls` + `ILlmBudgetGuard` avant appel | 3 | 2 | F2 |
+| O9 | **Limiteur de débit Raindrop partagé** — dans le client, pas dans un job | 2 | 2 | F10 |
+| O10 | **Journal d'identité au démarrage** — version, runtime, hôte, **jobs planifiés et leur cron** | 3 | 1 | F1, F15 |
+| O11 | **Healthcheck du conteneur MCP** | 2 | 1 | F1 |
+| O12 | **Renovate débloqué** — une virgule dans `renovate.json` | 2 | 1 | F8 |
+| N6 | **Rétention** — purge glissante des tables de journal | 1 | 1 | F11 |
+| C6 | **Newsletters Gmail → Raindrop, sous seuil** | 2 | 2 | D9 |
+| L7 | **Apprentissage des corrections humaines** — taux de correction par collection, puis few-shot dans le prompt | 3 | 2 | F12 |
+| S10 | **Exploitation des surlignages** — MCP `get_highlights`, injection dans la revue mensuelle | 3 | 1 | F4 |
+| S11 | **Expansion de requête** avant d'envisager `pgvector` | 2 | 1 | — |
+| S12 | **Export automatisé vers Obsidian** — variante 2 du pont, jamais écrite | 2 | 2 | — |
+
+## Ordre de bataille
+
+Six lots. L'ordre est contraint : **on ne construit rien de neuf tant qu'on peut tout perdre et dériver en coût sans le voir.**
+
+### Lot 11 — Reprendre la main sur l'exploitation
+
+Aucune valeur fonctionnelle visible, aucun appel LLM, aucun changement de schéma. C'est le lot qui rend le reste pilotable, et c'est celui qui doit passer en premier.
+
+- **O7 — Sauvegarde** ([#37](https://github.com/slucky31/LoreAI/issues/37)) : `pg_dump` planifié de la base `loreai` avec rotation, restauration **testée une fois** (une sauvegarde jamais restaurée n'est pas une sauvegarde), et copie chiffrée du `.env` de `mcm8` hors de la machine. Les deux actifs sont distincts et se perdent différemment — voir F9.
+- **O10 — Journal d'identité au démarrage** ([#65](https://github.com/slucky31/LoreAI/issues/65)) : version, runtime .NET, OS/architecture, hôte, **et la liste des jobs réellement planifiés avec leur expression cron**. Cette dernière partie n'est pas dans le ticket d'origine ; c'est elle qui ferme le trou F1 (« le projet ne sait pas ce qu'il fait tourner »). Code partagé dans `LoreAI.Infrastructure`, consommé par le Worker **et** le MCP — c'est le `StartupInfo` que `CLAUDE.md` décrit déjà mais qui n'a jamais été écrit (F15).
+- **O11 — Healthcheck MCP** ([#68](https://github.com/slucky31/LoreAI/issues/68)) : le mécanisme de #35 ne se transpose pas (pas de `CycleRuns` pour un serveur sans état). « En bonne santé » = le serveur répond et la connexion `loreai_ro` est vivante.
+- **O12 — Renovate** ([#40](https://github.com/slucky31/LoreAI/issues/40)) : virgule manquante ligne 5 de `renovate.json`. Vérifier ensuite que le Dependency Dashboard ([#9](https://github.com/slucky31/LoreAI/issues/9)) se repeuple.
+- **[#97](https://github.com/slucky31/LoreAI/issues/97)** — logs de `--add-watch-topic` en 4 lignes distinctes. Embarqué ici parce que le lot touche déjà à la journalisation.
+- **Ménage du backlog** : fermer les cinq issues livrées (#31, #35, #71, #73, #75) et les trois périmées (#33, #36, #39) — voir le triage ci-dessous. Corriger `CLAUDE.md` (F15).
+
+⚠️ Une part de ce lot n'est pas du code mais de l'exploitation sur `mcm8` (cron de `pg_dump`, dépôt de la sauvegarde chiffrée). Pas d'accès SSH depuis le bac à sable : produire des commandes copiables, comme le veut la convention du projet.
+
+### Lot 12 — Reprendre la main sur le coût
+
+Le lot qui empêche le prochain #99.
+
+- **D11 / [#99](https://github.com/slucky31/LoreAI/issues/99)** — retrait de la classification des flux RSS personnels. Périmètre de suppression déjà détaillé dans le ticket, y compris les points ouverts (sort de `SourceType.Feed` selon la présence de lignes en base, amendement du paragraphe lot 7 de `roadmap.md`).
+- **O8 — Garde-fou budget** (D8) : table `LlmCalls` (job appelant, modèle, tokens entrée/sortie/cache, coût estimé, horodatage) écrite par **tous** les appelants LLM — `AnthropicClassifier`, `AnthropicEmailLinkExtractor`, `AnthropicTopicWatchFilter`, `AnthropicThemeNarrativeGenerator`. Elle unifie les trois sources de mesure aujourd'hui éclatées (F2) et devient la source de S6, qui n'a plus à parser du `jsonb`. Puis `ILlmBudgetGuard` dans `Core` : consulté au début de chaque job consommateur, il refuse et journalise au-delà du seuil `Classifier__MonthlyBudgetUsd`. Une seule alerte Discord au franchissement, jamais une par appel refusé.
+- **[#34](https://github.com/slucky31/LoreAI/issues/34) — mesure du cache de prompt** : la table `LlmCalls` expose enfin `cache_creation_input_tokens` / `cache_read_input_tokens` en clair. La mesure de 30 minutes annoncée dans l'arbitrage devient une lecture de requête. **Trancher et fermer l'issue** — si les compteurs sont à zéro, le seuil de 4 096 tokens est confirmé et le sujet est clos jusqu'à un éventuel backfill.
+- **D10 / [#64](https://github.com/slucky31/LoreAI/issues/64)** — retrait de l'alerte Discord immédiate.
+
+Après ce lot, le coût est mesuré par job, plafonné, et la source non bornée est débranchée.
+
+### Lot 13 — Écritures externes : fiabilité et cohérence
+
+Trois écritures hors périmètre historique coexistent désormais (veille → Raindrop, file de lecture → tag Raindrop, et bientôt newsletters → Raindrop). Ce lot les met au même standard.
+
+- **O9 — Limiteur de débit Raindrop partagé** ([#86](https://github.com/slucky31/LoreAI/issues/86)) : au niveau de `RaindropClient`, pas dans `ReconciliationJob`. Six jobs partagent un token et plusieurs crons se croisent volontairement (dimanche 3h/4h/4h05) — un pacing dans un seul job ne protège de rien (F10).
+- **C6 / [#94](https://github.com/slucky31/LoreAI/issues/94)** — newsletters Gmail → Raindrop sous seuil (D9). Flag dédié `false` par défaut, tag `newsletter`, création jamais modification.
+- **[#98](https://github.com/slucky31/LoreAI/issues/98)** — marquer les entrées Miniflux de veille comme lues après évaluation. Dérogation ciblée à l'invariant ADR 0012, à documenter : il protège une catégorie **de lecture humaine**, pas une catégorie automatique que personne ne lit (F14).
+- **N6 — Rétention** : purge glissante de `CycleRuns`, `WatchEvaluationLogs`, `EmailExtractionLogs`. Une fois `LlmCalls` en place (lot 12), `ClassificationRawResponse` peut être réduit au-delà de 90 jours — la mesure de coût ne dépend plus de lui.
+- **[#92](https://github.com/slucky31/LoreAI/issues/92)** — harmonisation des logs entre les trois conteneurs. La partie horaire est déjà faite (#71, O4, livré) ; il reste le **format** commun et le cas de `miniflux`, qui a sa propre journalisation et ne se reformate pas depuis LoreAI. Requalifier le ticket sur ce qui reste réellement à faire.
+
+### Lot 10 — Déduplication inter-sources (**C5**, [#51](https://github.com/slucky31/LoreAI/issues/51))
+
+**Numéro et contenu inchangés** — l'issue existe sous ce nom et le renuméroter ne ferait que casser les références. Seule sa **position dans l'ordre** change : il passe après les trois lots de consolidation.
+
+Réutilise la normalisation d'URL de `DuplicateUrlDetector` (N1, déjà écrite) comme clé de rapprochement : un `Item` canonique, les autres rattachés comme occurrences, jamais de reclassification de ce qui l'a déjà été.
+
+Une nuance issue de D11 : avec la classification des flux personnels retirée, il ne reste plus que **trois** producteurs d'items classés (Raindrop, Newsletter, Veille) au lieu de quatre. Le besoin diminue d'autant — à réévaluer sur des chiffres réels (combien de doublons inter-sources le rapport hebdomadaire remonte-t-il aujourd'hui ?) **avant** d'attaquer le lot. C'est le seul lot de cette phase dont l'utilité mérite d'être vérifiée avant d'être construite.
+
+### Lot 14 — Refermer la boucle
+
+Le premier lot de cette phase qui crée de la valeur nouvelle. Les deux scénarios exploitent des données **déjà collectées**, sans rien ajouter à l'ingestion.
+
+- **L7 — Apprentissage des corrections humaines** (F12). Deux étapes, la première ayant de la valeur seule :
+  1. **Mesurer** : `ReconciliationJob` sait déjà qu'un article a été déplacé ou retagué après classification. En dériver un taux de correction par collection suggérée, exposé dans le rapport hebdomadaire. Réponse enfin factuelle à « est-ce que la classification est bonne ? », question à laquelle le projet ne sait pas répondre aujourd'hui.
+  2. **Corriger** : injecter les N corrections récentes comme exemples dans le prompt de classification. ⚠️ Interaction directe avec #34 — ajouter des exemples grossit le préfixe et peut faire franchir le seuil de cache de 4 096 tokens, ce qui change l'arbitrage. À traiter avec la mesure du lot 12 en main, pas avant.
+- **S10 — Surlignages** (F4) : outil MCP `get_highlights`, et injection des surlignages dans la revue mensuelle, où ils remplacent avantageusement un extrait tronqué. Zéro collecte à ajouter — la donnée est en base depuis le lot 1.
+
+À décider dans ce lot : **que fait-on de `important` et `broken`, à zéro sur 1 369 items** (F5) ? Soit on retire la section liens morts du rapport et `BrokenTrackedArticlesAnalyzer`, soit on sonde réellement les URLs — c'est-à-dire le crawler que N3 voulait éviter. Ne pas laisser un analyseur tourner pour produire du vide.
+
+### Lot 15 — Second cerveau
+
+La promesse d'origine encore non tenue : le corpus est interrogeable, il n'est pas encore *utilisé*.
+
+- **S11 — Expansion de requête** : mesurer d'abord si la recherche `tsvector` française échoue vraiment sur la synonymie et le mélange FR/EN. Un appel LLM court qui étend la requête avant recherche coûte bien moins qu'un embedding du corpus entier. **Décision `pgvector` reportée après cette mesure** — et rappel : le coût récurrent de génération des vecteurs reste entier, même si l'extension est disponible sans dépendance (D7).
+- **S12 — Export automatisé vers Obsidian** : la variante 2 du pont, jamais écrite. `tool_card` et `export_item` existent côté MCP mais restent manuels, donc peu utilisés. Un petit CLI côté PC (jamais côté Pi — D4) qui interroge le MCP et écrit les `.md`, déclenché par une tâche planifiée Windows. Les fiches sont **régénérées, jamais éditées** ; les annotations humaines vivent dans un fichier voisin.
+
+---
+
+## Triage complet des issues ouvertes
+
+Les 22 issues ouvertes au 2026-08-30, avec un verdict pour chacune.
+
+### À fermer — déjà livré (5)
+
+| Issue | Preuve dans le code |
+|---|---|
+| [#31](https://github.com/slucky31/LoreAI/issues/31) Compte-rendu de cycle Discord | `DiscordCycleReportNotifier`, règle « pas d'import, pas de notification » appliquée |
+| [#35](https://github.com/slucky31/LoreAI/issues/35) Healthcheck Docker/Portainer | `HEALTHCHECK` en forme exec, `src/LoreAI.Worker/Dockerfile:58` |
+| [#71](https://github.com/slucky31/LoreAI/issues/71) Logs en heure de Paris | `zoneinfo` copié depuis l'étage build + `ENV TZ=Europe/Paris`, dans les deux Dockerfiles |
+| [#73](https://github.com/slucky31/LoreAI/issues/73) Lien projet dans la base d'outils | `toolUrl` dans le schéma du tool `classify`, migration `AddToolUrl` |
+| [#75](https://github.com/slucky31/LoreAI/issues/75) Déclenchement manuel des jobs lents | `--run-weekly-insights` / `--run-monthly-review`, `Program.cs:214-226` |
+
+> ⚠️ Fermer #35 laisse ouverte la question **autoheal**, qui y était rattachée. Recommandation : ne pas ouvrir de ticket pour l'instant — `CycleRuns` existe désormais pour mesurer la fréquence réelle des blocages, et rien n'a été observé en trois mois. À reconsidérer sur données, dans six mois.
+
+### À fermer — périmé (3)
+
+| Issue | Pourquoi |
+|---|---|
+| [#33](https://github.com/slucky31/LoreAI/issues/33) Comparaison Versionize | Corps vide, et Versionize fonctionne — 12 releases automatiques jusqu'à 0.20.0. Rien à trancher |
+| [#36](https://github.com/slucky31/LoreAI/issues/36) Renommage de conteneur | Le compose actuel déclare `loreai-worker`, `loreai-mcp`, `miniflux`. Sans objet |
+| [#39](https://github.com/slucky31/LoreAI/issues/39) Déploiement Pi | Décrit l'édition manuelle de `image:` et `/data/raindropai.db`, disparu depuis l'ADR 0009. Le déploiement est documenté et se fait par `pull` GHCR |
+
+### Loties (11)
+
+| Issue | Lot | Note |
+|---|---|---|
+| [#37](https://github.com/slucky31/LoreAI/issues/37) Sauvegarde | **11** | Requalifier : deux actifs distincts (base + `.env`), restauration à tester |
+| [#65](https://github.com/slucky31/LoreAI/issues/65) Version/env au démarrage | **11** | Étendre au **listing des jobs planifiés** — c'est ce qui ferme F1 |
+| [#68](https://github.com/slucky31/LoreAI/issues/68) Healthcheck MCP | **11** | |
+| [#40](https://github.com/slucky31/LoreAI/issues/40) Renovate cassé | **11** | Virgule manquante, `renovate.json:5` |
+| [#97](https://github.com/slucky31/LoreAI/issues/97) Logs `--add-watch-topic` | **11** | |
+| [#99](https://github.com/slucky31/LoreAI/issues/99) Retrait classification RSS perso | **12** | Périmètre déjà instruit dans le ticket |
+| [#34](https://github.com/slucky31/LoreAI/issues/34) Cache de prompt | **12** | Devient une lecture de `LlmCalls`. À **trancher et fermer** dans le lot |
+| [#64](https://github.com/slucky31/LoreAI/issues/64) Alerte immédiate | **12** | Décidé : retrait (D10) |
+| [#86](https://github.com/slucky31/LoreAI/issues/86) Throttle Raindrop | **13** | Requalifier : le limiteur va dans `RaindropClient`, pas dans `ReconciliationJob` |
+| [#94](https://github.com/slucky31/LoreAI/issues/94) Newsletters → Raindrop | **13** | Décidé : oui, sous seuil (D9) |
+| [#98](https://github.com/slucky31/LoreAI/issues/98) Marquer les entrées de veille lues | **13** | |
+
+### À requalifier (2)
+
+| Issue | Ce qu'il en reste |
+|---|---|
+| [#92](https://github.com/slucky31/LoreAI/issues/92) Harmoniser les logs des 3 conteneurs | La partie horaire est faite (#71). Reste le format commun, et le cas de `miniflux` qui ne se reformate pas depuis LoreAI. Lot 13 |
+| [#51](https://github.com/slucky31/LoreAI/issues/51) Lot 10 — déduplication | Garde son numéro et son contenu, **repositionné après les lots 11-13**. Utilité à revérifier sur chiffres réels avant d'attaquer |
+
+### Laissée telle quelle (1)
+
+[#9](https://github.com/slucky31/LoreAI/issues/9) Dependency Dashboard — issue technique de Renovate, ne se ferme pas. À surveiller après le correctif O12 : si elle ne se repeuple pas, le correctif n'a pas pris.
+
+### Issues à ouvrir
+
+Ces scénarios n'ont pas encore de ticket :
+
+| # | Titre proposé | Lot |
+|---|---|---|
+| O8 | Garde-fou budget LLM — table `LlmCalls` + `ILlmBudgetGuard` avant appel | 12 |
+| N6 | Rétention des tables de journal (`CycleRuns`, `WatchEvaluationLogs`, `EmailExtractionLogs`) | 13 |
+| L7 | Apprentissage des corrections humaines — mesure puis few-shot | 14 |
+| S10 | Exploitation des surlignages — MCP `get_highlights` + revue mensuelle | 14 |
+| — | Trancher le sort de `important`/`broken` (0 sur 1 369 items) | 14 |
+| S11 | Expansion de requête avant d'envisager `pgvector` | 15 |
+| S12 | Export automatisé vers Obsidian (CLI côté PC) | 15 |
+| A1 | Newsletters : décoder les segments base64 des URLs de tracking avant le filtre de bruit — un lien `preferences-confirmed` est classé `Haute` et 2ᵉ de la file de lecture | 13 |
+| A2 | Temps de lecture constant à 1 min en tête de file : mesurer le taux d'échec de `ContentStatus` par domaine (`lnkd.in` en tête) | 14 |
+| A3 | Catalogue d'outils : `status` reste « À évaluer » pour les 21 outils — retirer le champ, ou livrer Q3 pour le renseigner | 14 |
+
+Les trois dernières sont des anomalies **observées sur des données réelles** le 2026-08-30, détaillées dans [`reste-a-tester.md`](reste-a-tester.md#-anomalies-trouvées-en-vérifiant).
+
+---
+
+## Risques propres à cette phase
+
+Les risques de [`roadmap.md`](roadmap.md#risques-et-points-de-vigilance) restent valables. Ceux-ci s'y ajoutent.
+
+| Risque | Mitigation |
+|---|---|
+| **Trois lots sans valeur visible d'affilée** (11, 12, 13) — démotivant, et la tentation de sauter au lot 14 sera forte | Assumé et explicite : le lot 11 protège contre une perte irréversible, le 12 contre une facture. Aucun des deux ne se rattrape après coup. Le lot 14 n'est pas plus loin que 3 semaines de rythme observé |
+| **Le garde-fou budget coupe le pipeline au mauvais moment** — un plafond atteint le 20 du mois arrête la classification pour 10 jours | Le garde-fou ne coupe que les **appels LLM**, jamais l'ingestion ni la persistance : les articles continuent d'entrer, ils sont classés en repli et rattrapables. Alerte au franchissement, seuil configurable, et `Worker__WriteBackToRaindrop` reste indépendant |
+| **`LlmCalls` devient une troisième source de vérité du coût** à côté du `jsonb` existant | Migration complète dans le même lot : S6 lit `LlmCalls` et **cesse** de parser `ClassificationRawResponse`. Deux sources coexistantes seraient pire que l'état actuel |
+| **L7 étape 2 casse l'arbitrage du cache de prompt** — les exemples grossissent le préfixe | C'est aussi une opportunité (franchir enfin le seuil de 4 096 tokens). À traiter avec la mesure du lot 12 en main. Ne pas faire L7-2 avant que #34 soit tranchée |
+| **Le retrait de l'alerte immédiate (D10) rouvre le trou « rien ne se perd »** | Contrairement à l'analyse d'août, le filet existe désormais : file de lecture hebdomadaire (L1/L5) et compte-rendu de cycle, tous deux livrés. Si le manque se fait sentir, `INotificationPolicy` est réintroductible — mais on attend le manque, on ne l'anticipe pas |
+| **La règle « un lot fini = un lot actif » ralentit la livraison** | C'est l'objectif. Le rythme actuel produit des lots que personne n'active — et donc de la valeur nulle malgré le travail fait |
+| **La sauvegarde n'est pas testée** | Une restauration réelle est **dans** le périmètre du lot 11, pas un « à faire plus tard ». Une sauvegarde jamais restaurée n'est pas une sauvegarde |
+
+## Questions ouvertes
+
+- **La règle « un lot fini = un lot actif »** — à valider ou refuser explicitement. Elle change la définition de terminé pour tous les lots suivants.
+- **Utilité réelle du lot 10 (déduplication)** — à mesurer sur le rapport hebdomadaire actuel avant de l'attaquer. Avec le retrait des flux personnels, il ne reste que trois producteurs d'items.
+- **Sort de `important` / `broken`** — retirer l'analyseur, ou sonder réellement les URLs ? À trancher au lot 14.
+- **`pgvector`** — reste conditionné à l'échec mesuré de S11, jamais ouvert par anticipation.
+- **Autoheal** — laissé sans ticket, à reconsidérer sur données `CycleRuns` dans six mois.
+- **Abonnement Claude en mode headless** — inchangé depuis la phase 1 : faisabilité établie, conditions d'usage non vérifiées, enjeu de quelques euros. Ne pas loter.
+- **« Hermes »** — toujours non identifié (question ouverte héritée de la phase 1).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,8 @@
 # Roadmap — exploiter le contenu classé
 
+> **⚠️ Ce document couvre les phases 1 et 2 (lots 0 → 9), toutes livrées.** Il reste la référence pour les décisions **D1-D7**, les arbitrages tranchés (PostgreSQL, coût LLM, cache de prompt, Miniflux, OpenClaw) et les scénarios C/N/S/L/Q/O d'origine.
+> **La suite est dans [`roadmap-phase-3.md`](roadmap-phase-3.md)** (décisions D8-D11, lots 11 → 15, triage des issues), motivée par la [critique fonctionnelle du 2026-08-30](critique-fonctionnelle.md).
+
 ## Pourquoi ce document
 
 LoreAI ne fait aujourd'hui que la moitié du travail : il capte les nouveaux articles de « Non trié », les classe, les range, puis notifie (Discord immédiat, digest mail quotidien). Le résultat n'est qu'un **flux sortant** : une fois l'article rangé et l'email envoyé, la base ne sert plus à rien. `ArticleRepository` ne contient d'ailleurs qu'un seul `SELECT` (`GetUnsentDigestItemsAsync`) — tout le reste du schéma est en écriture seule.
@@ -355,6 +358,8 @@ Ne commence qu'une fois le lot 4 livré : les deux connecteurs ont besoin de l'e
 
 **Décision revue en cours de lot (2026-08-29)** : livré via **Miniflux auto-hébergé** plutôt que par l'ingestion RSS directe initialement prévue ici (`FeedIngester`/`System.ServiceModel.Syndication`). Miniflux gère abonnements, parsing et santé des flux, et sert aussi d'interface de lecture humaine (remplace Feedly) — couvrant en un seul déploiement les deux besoins que l'arbitrage « Miniflux auto-hébergé » ci-dessous distinguait, plutôt que de les séquencer (ingestion directe d'abord, Miniflux ensuite *si* besoin de lecture). `MinifluxIngester` (`IFeedIngester`) consomme `GET /v1/entries` de l'instance Miniflux, curseur sur l'id d'entrée Miniflux (pas de backfill automatique au premier démarrage, même choix que `GmailIngester`). Les entrées deviennent des `Item` avec `SourceType = Feed` et passent dans le pipeline de classification existant, sans jamais écrire dans Miniflux ni Raindrop (ADR 0012). PR [#87](https://github.com/slucky31/LoreAI/pull/87), déploiement documenté dans `docs/deploiement-raspberry-pi.md` (section 12).
 
+⚠️ **Amendé le 2026-08-30 — la classification des flux personnels est retirée** ([#99](https://github.com/slucky31/LoreAI/issues/99), décision **D11** de la [phase 3](roadmap-phase-3.md)). Le coût de ce volet n'avait jamais été modélisé : le tableau de coût ci-dessous ne couvre que « Non trié », borné par les sauvegardes humaines, alors qu'un abonnement RSS ne l'est pas — chiffrage a posteriori ~36 $/mois à 100 entrées/jour, contre un budget de référence de 10 €/mois, pour une valeur produite quasi nulle (aucune écriture nulle part, ADR 0012). `FeedIngestionJob`/`MinifluxIngester` sont supprimés au **lot 12**. **Le cœur du lot reste livré** : Miniflux demeure l'interface de lecture humaine (remplace Feedly) et le moteur RSS de la veille (lot 9) — même instance, même API, `Miniflux__*` inchangé.
+
 - **O6** rapport hebdomadaire mobile-friendly ([#78](https://github.com/slucky31/LoreAI/issues/78)) — sans rapport avec le connecteur RSS, embarqué ici parce que c'est le prochain lot ouvert, même raison qu'O4/S9/O5 au lot 6. Livré : `WeeklyInsightsJob` envoie désormais un digest Discord natif (embeds, deux messages actionnable/hygiène, 10 entrées + total par section) via `IWeeklyDigestNotifier`/`DiscordWeeklyDigestNotifier`, plus une pièce jointe `.md` — `MonthlyReviewJob` conserve le format narratif inchangé. PR [#88](https://github.com/slucky31/LoreAI/pull/88).
 
 #### Lot 8 — Connecteur newsletters Gmail (**C2**)
@@ -385,6 +390,8 @@ Construit sur le lot 7, comme prévu, avec la contrainte RSS-d'abord respectée 
 #### Lot 10 — Déduplication inter-sources (**C5**)
 
 Une fois trois sources actives, le même article arrive plusieurs fois. Réutilise la normalisation d'URL de N1 comme clé de rapprochement, avec un `Item` canonique et des occurrences rattachées.
+
+⚠️ **Repositionné le 2026-08-30** : numéro et contenu inchangés, mais exécuté **après** les lots de consolidation 11-13 de la [phase 3](roadmap-phase-3.md). Avec le retrait de la classification des flux personnels (D11), il ne reste que **trois** producteurs d'items classés au lieu de quatre — l'utilité du lot est à revérifier sur les doublons réellement remontés par le rapport hebdomadaire **avant** de l'attaquer.
 
 ## Arbitrages tranchés
 


### PR DESCRIPTION
## Pourquoi

La roadmap des phases 1 et 2 est épuisée : les lots 0 à 9 sont livrés, il ne reste que le lot 10 (déduplication, #51). Revue complète du code, des 22 issues ouvertes et de la production (`mcm8`, v0.20.0, 1 369 items interrogés via le serveur MCP) pour établir la suite.

Documentation seule, **aucun changement de code**.

## Ce que la revue a trouvé

Les constats les plus graves, chacun adossé à un fichier, une issue ou une mesure — pas à la documentation :

- **Aucune sauvegarde.** Ni `pg_dump` de la base, ni copie du `.env` de `mcm8` (7 secrets qui n'existent nulle part ailleurs, dont un refresh token OAuth Google). Le lot 0 posait pourtant la règle « `pg_dump` avant de supprimer le `.db` » — le `.db` a été supprimé.
- **Le coût LLM n'est mesuré qu'a posteriori**, une fois par semaine. Aucun code ne peut refuser un appel parce que le budget est dépassé : c'est ce qui a laissé passer le volet RSS du lot 7 à ~36 $/mois estimés (#99).
- **Renovate est bloqué** par une virgule manquante dans `renovate.json:5`. Aucune mise à jour de dépendance ne passe.
- **5 issues sur 22 sont livrées mais toujours ouvertes** (#31, #35, #71, #73, #75), 3 sont périmées (#33, #36, #39).
- **Le signal des corrections humaines est capté puis jeté** : `ReconciliationJob` sait qu'un article a été déplacé ou retagué après classification — donc que le modèle s'est trompé — et rien ne s'en sert pour améliorer le prompt suivant.
- **Données collectées et jamais relues** : surlignages (`HighlightsJson`), et `important`/`broken` à **0 sur 1 369 items** — `BrokenTrackedArticlesAnalyzer` tourne pour produire du vide.

## Anomalies trouvées sur données réelles

Trois défauts que seule l'observation de la production pouvait révéler, détaillés dans `reste-a-tester.md` :

- **A1** — la 2ᵉ entrée de la file de lecture, classée `Priorité Haute`, est en réalité `https://app.kit.com/preferences-confirmed` (décodé depuis un segment base64 d'un redirecteur de tracking Kit). `EmailLinkNoiseFilter` cherche `preferences`/`unsubscribe` en clair, pas encodés.
- **A2** — les 5 premières entrées ont toutes `estimatedMinutes: 1` (essentiellement des `lnkd.in`) : le score L1 « priorité × fraîcheur × temps de lecture » n'a de fait que deux facteurs.
- **A3** — les 21 outils du catalogue sont tous en `status: "À évaluer"` : rien ne fait jamais avancer ce champ, le « verdict » promis par S7 est mort.

Au passage, un flag inconnu est levé : **`Worker__EmailIngestionEnabled` est bien actif** en production (entrée `sourceType: Newsletter` du 2026-08-30).

## Décisions actées en session

| # | Décision | Lot |
|---|---|---|
| **D8** | Budget LLM 10 €/mois **avec garde-fou dur** dans le code (`LlmCalls` + `ILlmBudgetGuard` consulté avant appel) | 12 |
| **D9** | Newsletters Gmail réinjectées dans Raindrop **sous seuil** (#94) | 13 |
| **D10** | Retrait de l'alerte Discord immédiate `ATester`/`Haute` (#64) | 12 |
| **D11** | Retrait de la classification des flux RSS personnels (#99) — Miniflux reste lecteur humain et moteur de la veille | 12 |

## Lotissement proposé

| Lot | Contenu | Pourquoi là |
|---|---|---|
| **11** Exploitation | sauvegarde, identité au démarrage + jobs planifiés, healthcheck MCP, Renovate, ménage du backlog | on ne construit rien tant qu'on peut tout perdre |
| **12** Coût | retrait RSS (#99), garde-fou budget, mesure du cache (#34), retrait alerte (#64) | on ne construit rien tant qu'on dérive sans le voir |
| **13** Écritures externes | limiteur Raindrop (#86), Gmail→Raindrop (#94), Miniflux marqué lu (#98), rétention | met les 3 écritures hors périmètre au même standard |
| **10** Dédup (#51) | inchangé, **repositionné** | utilité à revérifier : plus que 3 producteurs d'items après D11 |
| **14** Boucle | apprentissage des corrections humaines, surlignages | première valeur nouvelle, sur données déjà collectées |
| **15** Second cerveau | expansion de requête (avant `pgvector`), export Obsidian automatisé | la promesse d'origine encore non tenue |

Trois lots sans valeur visible d'affilée : c'est assumé et argumenté dans le document.

## Fichiers

- `docs/critique-fonctionnelle.md` *(nouveau)* — 15 constats avec preuves, propositions cotées V/E, et ce que je ne recommande pas.
- `docs/roadmap-phase-3.md` *(nouveau)* — décisions D8-D11, 6 lots, triage complet des 22 issues, risques, questions ouvertes.
- `docs/reste-a-tester.md` *(nouveau)* — ce qui n'a jamais été vérifié en conditions réelles, un critère de réussite par ligne, trous de couverture automatisée.
- `docs/roadmap.md` — bandeau de renvoi, amendement du lot 7 (D11), repositionnement du lot 10.
- `docs/etat-des-lieux.md` — réécrit selon sa convention.

## En attente de décision

- **La règle « un lot n'est fini que s'il est actif en production »** est écrite comme proposition, pas comme décision : 4 des 6 derniers lots sont désactivés par défaut. Elle ralentit délibérément la livraison.
- **7 issues restent à ouvrir** (garde-fou budget, rétention, L7, S10, sort de `important`/`broken`, S11, S12) plus les 3 anomalies A1-A3 — la liste avec titres et lots est dans `roadmap-phase-3.md`. Non créées sans validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WyZNVJqxbbHuKANbWPs3Zx
